### PR TITLE
fixed sorting by text comparison instead of numerical

### DIFF
--- a/tcf_website/static/common/sorting.js
+++ b/tcf_website/static/common/sorting.js
@@ -22,12 +22,12 @@ function cmpByProp(prop, asc) {
             valB = dateToInt(valB);
         } else { // extract number from string
             try {
-                valA = valA.match(/-?[0-9]\d*(\.\d+)?/)[0];
+                valA = parseFloat(valA.match(/-?[0-9]\d*(\.\d+)?/)[0]);
             } catch (err) {
                 return 1;
             }
             try {
-                valB = valB.match(/-?[0-9]\d*(\.\d+)?/)[0];
+                valB = parseFloat(valB.match(/-?[0-9]\d*(\.\d+)?/)[0]);
             } catch (err) {
                 return -1;
             }


### PR DESCRIPTION
# Status
Done, In progress, etc

# What I did

Changed the common sorting script to sort reviews/classes using numerical comparison rather than string comparison (35 > 2). Very simple two-line change to parse as a float after regex.

## Issues addressed

#189 

## Screenshots

N/A but can go to any course/review page to sort