### PR TITLE
Added latest semester to old professor classes

### DIFF
--- a/tcf_website/models/models.py
+++ b/tcf_website/models/models.py
@@ -199,6 +199,15 @@ class Instructor(models.Model):
         # implies (collecting Sections instead of Courses); work in progress
         return Section.objects.filter(instructors=self)
 
+    def last_taught(self, course):
+        """Returns the latest semester a professort taught a section of a specific course."""
+        # Probably inefficient and similar comments as taught_courses above
+        # However, the is not called that many times so there is no noticable
+        # delay
+        return Section.objects.filter(
+            instructors=self,
+            course=course).order_by("-semester").first().semester
+
     def average_rating(self):
         """Compute average rating for all this Instructor's Courses"""
         ratings = Review.objects.filter(instructor=self).aggregate(

--- a/tcf_website/templates/course/course.html
+++ b/tcf_website/templates/course/course.html
@@ -41,10 +41,10 @@
                         {% include "common/rating_card.html" with title=i.full_name link=link rating=i.rating difficulty=i.difficulty last_taught=course.semester_last_taught %}
                     </li>
                 {% endfor %}
-                {% for i in old_instructors %}
+                {% for i in old_instructors|dictsortreversed:"number" %}
                     <li class="instructor old">
                         {% url 'course_instructor' course_id=course.pk instructor_id=i.pk as link %}
-                        {% include "common/rating_card.html" with title=i.full_name link=link rating=i.rating difficulty=i.difficulty %}
+                        {% include "common/rating_card.html" with title=i.full_name link=link rating=i.rating difficulty=i.difficulty last_taught=i.last_taught_sem%}
                     </li>
                 {% endfor %}
             </ul>

--- a/tcf_website/views/browse.py
+++ b/tcf_website/views/browse.py
@@ -85,10 +85,13 @@ def course_view(request, course_id):
         'instructors',
         flat=True).distinct()
     old_instructors = Instructor.objects.filter(pk__in=old_instructor_pks)
-    # Add ratings and difficulties
+    # Add ratings, difficulties, and semester
+    # Also passes in the semster number for sorting in template
     for instr in old_instructors:
         instr.rating = instr.average_rating_for_course(course)
         instr.difficulty = instr.average_difficulty_for_course(course)
+        instr.last_taught_sem = instr.last_taught(course)
+        instr.number = instr.last_taught_sem.number
 
     dept = course.subdepartment.department
 


### PR DESCRIPTION
# Status
Done, In progress, etc

# What I did

Fixed a bug where the last semester taught by old professors aren't showing in the course list

Modified models to add a last_taught method to instructors as well as changes to browse view and course template to display and sort. 

## Issues addressed

## Screenshots

Old:
![image](https://user-images.githubusercontent.com/26658168/99154226-25635880-267c-11eb-824f-edb2312df1b7.png)

New:
![image](https://user-images.githubusercontent.com/26658168/99154233-3744fb80-267c-11eb-92dc-f15b5a447e64.png)
