### PR TITLE
Refactor and improve the speed of /course/{course_id}

### DIFF
--- a/tcf_website/templates/course/course.html
+++ b/tcf_website/templates/course/course.html
@@ -37,16 +37,10 @@
             <br/>
 
             <ul class="instructor-list">
-                {% for i in recent_instructors %}
-                    <li class="instructor">
+                {% for i in instructors %}
+                    <li class="instructor {% if i.semester_last_taught != latest_semester %}old{% endif %}">
                         {% url 'course_instructor' course_id=course.pk instructor_id=i.pk as link %}
-                        {% include "common/rating_card.html" with title=i.full_name link=link rating=i.rating difficulty=i.difficulty gpa=i.gpa last_taught=course.semester_last_taught %}
-                    </li>
-                {% endfor %}
-                {% for i in old_instructors %}
-                    <li class="instructor old">
-                        {% url 'course_instructor' course_id=course.pk instructor_id=i.pk as link %}
-                        {% include "common/rating_card.html" with title=i.full_name link=link rating=i.rating difficulty=i.difficulty gpa=i.gpa %}
+                        {% include "common/rating_card.html" with title=i.full_name link=link rating=i.rating difficulty=i.difficulty gpa=i.gpa last_taught=i.semester_last_taught %}
                     </li>
                 {% endfor %}
             </ul>


### PR DESCRIPTION
# Status
Done

# What I did
- added `semester_last_taught` to "old" professors
- refactored a Django view (`course_view`) to reduce unnecessary database access
  - changed `course.html` accordingly

## Issues addressed
This fixes #243 and supercedes #218.

## Screenshots
![image](https://user-images.githubusercontent.com/7676354/99673030-94dfaa80-2ab7-11eb-83ea-3dfa2db6c16c.png)
As you can see, the performance difference between and after the refactoring is dramatic. Note that the requests in the red box do not even include `semester_last_taught` for "old" professors, while the requests in the green box do.