### PR TITLE
Fix semester casing in write-review page

### DIFF
--- a/tcf_website/api/serializers.py
+++ b/tcf_website/api/serializers.py
@@ -6,6 +6,11 @@ from ..models import (Course, Department, School, Instructor, Semester,
 
 class SemesterSerializer(serializers.ModelSerializer):
     """DRF Serializer for Semester"""
+    season = serializers.SerializerMethodField()
+
+    def get_season(self, obj):
+        return obj.season.title()
+
     class Meta:
         model = Semester
         fields = '__all__'

--- a/tcf_website/api/serializers.py
+++ b/tcf_website/api/serializers.py
@@ -9,6 +9,8 @@ class SemesterSerializer(serializers.ModelSerializer):
     season = serializers.SerializerMethodField()
 
     def get_season(self, obj):
+        """Change the `season` field to TitleCase (or PascalCase)"""
+        # pylint: disable=no-self-use
         return obj.season.title()
 
     class Meta:

--- a/tcf_website/api/serializers.py
+++ b/tcf_website/api/serializers.py
@@ -1,3 +1,4 @@
+# pylint: disable=no-self-use
 """DRF Serializers"""
 from rest_framework import serializers
 from ..models import (Course, Department, School, Instructor, Semester,
@@ -10,7 +11,6 @@ class SemesterSerializer(serializers.ModelSerializer):
 
     def get_season(self, obj):
         """Change the `season` field to TitleCase (or PascalCase)"""
-        # pylint: disable=no-self-use
         return obj.season.title()
 
     class Meta:

--- a/tcf_website/static/department/loadMoreCourses.js
+++ b/tcf_website/static/department/loadMoreCourses.js
@@ -22,8 +22,6 @@ function generateCourseCardHTML(course) {
     const rating = emdashOrTwoDecimals(course.average_rating);
     const difficulty = emdashOrTwoDecimals(course.average_difficulty);
     const gpa = emdashOrTwoDecimals(course.average_gpa);
-    const seasonAllCaps = course.semester_last_taught.season;
-    const seasonTitleCase = seasonAllCaps.charAt(0) + seasonAllCaps.substr(1).toLowerCase();
     return `
         <li class="${course.is_recent ? "" : "old"}">
             <div class="card rating-card mb-2">
@@ -63,7 +61,7 @@ function generateCourseCardHTML(course) {
                                 <small class="mb-0 text-uppercase">
                                     Last Taught
                                 </small>
-                                <p class="mb-0 info">${seasonTitleCase} ${course.semester_last_taught.year}</p>
+                                <p class="mb-0 info">${course.semester_last_taught.season} ${course.semester_last_taught.year}</p>
                             </div>
                         </div>
                             <p class="card-text mt-2">${course.description}</p>


### PR DESCRIPTION
# Status
Done

# What I did
- Change how `season` is cased in the API. 
  - Note that other APIs are also affected because `SemesterSerializer` is often nested in another serializer.

## Issues addressed

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/7676354/100352883-fca27200-3030-11eb-9a2f-e9725d2392a0.png)

After:
![image](https://user-images.githubusercontent.com/7676354/100352847-f01e1980-3030-11eb-8cf9-fae189cd00d0.png)
