### PR TITLE
Force-redirect to HTTPS on Heroku

### DIFF
--- a/tcf_core/settings.py
+++ b/tcf_core/settings.py
@@ -187,6 +187,7 @@ if not DEBUG:
     if env.bool("HEROKU", default=False):
         import django_heroku
         django_heroku.settings(locals())
+        SECURE_SSL_REDIRECT = True
 
     # Gather information from environment variables.
 


### PR DESCRIPTION
# Status
Done

# What I did
- Redirected all HTTP requests to HTTPS by adding a single line in `settings.py`
  - We only need to write HTTPS URLs on Google Developer Console (effectively preventing issues like [this](https://discord.com/channels/752270432329269328/764555745806647317/767068336852566046))

## Issues addressed
- Closes #285 