### PR TITLE
Add black

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Run pylint
         run: pylint --load-plugins pylint_django tcf_website tcf_core
 
+      - name: Run black
+        uses: psf/black@stable
+
       - name: Migrations & Tests
         run: |
           mkdir tcf_website/migrations

--- a/.github/workflows/master-to-app-engine.yml
+++ b/.github/workflows/master-to-app-engine.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Run pylint
         run: pylint --load-plugins pylint_django tcf_website tcf_core
 
+      - name: Run black
+        uses: psf/black@stable
+
       - name: Migrations & Tests
         run: |
           mkdir tcf_website/migrations

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,3 @@
+# Config to make pylint compatible with black
+disable = C0330, C0326
+max-line-length = 88

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,5 @@
+[MESSAGES CONTROL]
 # Config to make pylint compatible with black
 disable = C0330, C0326
+[FORMAT]
 max-line-length = 88

--- a/precommit
+++ b/precommit
@@ -1,5 +1,5 @@
-# Auto format.
-docker exec tcf_django autopep8 --in-place --aggressive --aggressive -r tcf_website tcf_core
+# Black auto format. Will automatically fix any noncompliant code
+docker exec tcf_django black tcf_website tcf_core
 # Lint.
 docker exec tcf_django pylint --load-plugins pylint_django tcf_website tcf_core
 docker exec tcf_django node_modules/.bin/eslint --fix tcf_website/static/**/*.js

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ django-filter
 # Linting
 pylint>=2.4.4
 pylint-django>=2.0.14
-autopep8>=1.5.1
+black
 html-linter>=0.4.0
 
 # Heroku setup


### PR DESCRIPTION
# Status
In progress

- [ ] Add instructions in `FOR-DEVS` for black usage
- [x] Add black check to precommit
- [x] Add black to CI pipeline
- [ ] Run all files through black
- [ ] Test to ensure everything works

# What I did
Add black
black check checks that everything is formatted in compliance with black
## Issues addressed
- black autoformats files, so you don't have to precommit to check if your formatting is correct (can be used in vscode to format on save)
- black is highly opinionated, eliminating pedantic disputes about formatting

### Drawbacks
- black uses double quotes which could be controversial
- black can make breaking changes or unwanted changes to code (it is still in beta) so you can use `# fmt off`
- it will muddy the commit history since most files are being touched
## Questions
1. Do I need to specify tcf_website and tcf_core in continuous_integration.yml
2. Do I need to add disable tags for pylint in continuous_integration.yml or does it use the .pylintrc file automatically
3. Is there some folders that should be excluded (e.g. migrations)