### PR TITLE
Added better feedback for review account wall

### DIFF
--- a/tcf_website/templates/base/sidebar.html
+++ b/tcf_website/templates/base/sidebar.html
@@ -13,7 +13,9 @@
          <hr>
       </a>
     </li>
+    <!-- Account wall for writing reviews -->
     <li>
+    {% if user.is_authenticated %}
       <a href="{% url 'new_review' %}"
          class="list-group-item list-group-item-action pb-0
          {% if request.resolver_match.url_name == 'new_review' %}active{% endif %}">
@@ -21,7 +23,15 @@
         <p>Review</p>
         <hr>
       </a>
-    </li>
+    {% else %}
+      <a href="#loginModal" data-toggle="modal"
+        class="list-group-item list-group-item-action pb-0
+        {% if request.resolver_match.url_name == 'new_review' %}active{% endif %}">
+        <h4><i class="fa fa-pencil-square-o fa-fw"></i></h4>
+        <p>Review</p>
+        <hr>
+      </a>
+    {% endif %}
     <li>
       <a href="{% url 'about' %}"
          class="list-group-item list-group-item-action pb-0

--- a/tcf_website/templates/login/login_button.html
+++ b/tcf_website/templates/login/login_button.html
@@ -5,9 +5,8 @@
 {% endblock %}
 
 <div class="login-button-container m-0">
-  {% with request.resolver_match.view_name as view_name %}
     <!-- Redirect back to same page only if not on login error page -->
-    {% if view_name != 'tcf_website.views.auth.login_error' %}
+    {% if request.resolver_match.url_name != 'login_error' %}
         <a class="login-button-wrapper"
            href="{% url 'social:begin' 'google-oauth2' %}?next={{request.get_full_path}}">
             <button class="login-button"></button>
@@ -18,5 +17,4 @@
             <button class="login-button"></button>
         </a>
     {% endif %}
-  {% endwith %}
 </div>

--- a/tcf_website/urls.py
+++ b/tcf_website/urls.py
@@ -32,9 +32,9 @@ urlpatterns = [
     path('discord/', views.post_message, name='discord'),
 
     # AUTH URLS
-    path('login', views.login, name='login'),
-    path('login/error', views.login_error),
-    path('login/collect_extra_info', views.collect_extra_info),
-    path('accounts/login/', views.login),
+    # path('login', views.login, name='login'), # Changed to login modal
+    path('login/error', views.login_error, name='login_error'),
+    path('login/collect_extra_info', views.collect_extra_info, name='login_info'),
+    path('accounts/login/', views.login, name='login'),
     path('logout/', views.logout, name='logout'),
 ]

--- a/tcf_website/views/auth.py
+++ b/tcf_website/views/auth.py
@@ -14,6 +14,7 @@ def login(request):
     if request.user.is_authenticated:
         messages.success(request, "Logged in successfully!")
         return redirect('profile')
+    messages.add_message(request, messages.ERROR, "Login to view this page!")
     return browse(request)
     # Note: For some reason the data won't load if you use render like below:
     # return render(request, 'browse/browse.html')


### PR DESCRIPTION
# Status
Done? Need input.

# What I did
Fixed issue with `new_review` url redirecting back to browse when user is not authenticated
- Clicking on Review sidebar link will pop open login modal
- Trying to navigate to `/reviews/new` url will redirect to browse and show an error alert "Login is required to view this page"

## Additional Notes
Actually not the best solution, but it'll do for now. 
- If we want a fully fluid login modal (that doesn't redirect to browse on login error) we likely will have to create a custom AJAX `login_required` decorator https://stackoverflow.com/questions/312925/django-authentication-and-ajax-urls-that-require-login
- Not sure this is worth doing until we make a decision on the login system overhaul, possibly to add MS exchange/professor accounts

## Screenshots
| Sidebar link click     | URL navigation |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/4724192/102706464-19ad1800-4260-11eb-9609-20068a5e87af.png) | ![image](https://user-images.githubusercontent.com/4724192/102706452-fd10e000-425f-11eb-9884-2eb6977dd094.png) |