### PR TITLE
Add 'deleted review' message on reviews page

### DIFF
--- a/tcf_website/tests/test_review.py
+++ b/tcf_website/tests/test_review.py
@@ -7,7 +7,6 @@ from django.contrib.messages import get_messages
 from django.test import TestCase
 from django.urls import reverse
 
-from .test_utils import setup
 from .test_utils import setup, suppress_request_warnings
 
 
@@ -80,6 +79,7 @@ class EditReviewTests(TestCase):
         messages = [m.message for m in get_messages(response.wsgi_request)]
         self.assertIn('difficulty', str(messages[0]))
 
+
 class DeleteReviewTests(TestCase):
     """Tests for the DeleteReview view."""
 
@@ -101,6 +101,7 @@ class DeleteReviewTests(TestCase):
         messages = [m.message for m in get_messages(response.wsgi_request)]
         self.assertEqual(str(messages[0]), 'Successfully deleted your review!')
 
+    @suppress_request_warnings
     def test_delete_nonexistent_review_id(self):
         """Test if a 404 is returned for deleting a nonexistent review ID."""
         self.client.force_login(self.user1)
@@ -110,6 +111,7 @@ class DeleteReviewTests(TestCase):
 
         self.assertEqual(response.status_code, 404)
 
+    @suppress_request_warnings
     def test_unauthorized_user_delete(self):
         """Test if a 403 is returned for unauthorized review deletion."""
         self.client.force_login(self.user2)  # force login as user2

--- a/tcf_website/tests/test_review.py
+++ b/tcf_website/tests/test_review.py
@@ -1,0 +1,57 @@
+# pylint: disable=no-member
+"""Tests for Review model."""
+
+from django.contrib.messages import get_messages
+from django.test import TestCase
+from django.urls import reverse
+
+
+from .test_utils import setup
+
+
+class DeleteReviewTests(TestCase):
+    """Tests for the DeleteReview view."""
+
+    def setUp(self):
+        setup(self)  # set up tests: add some example data
+
+    def test_delete_review_message(self):
+        """Test if a message is shown when a user deletes their review."""
+        self.client.force_login(
+            self.review1.user)  # force a login as the author of review1
+        # try and make the user delete review1
+        response = self.client.post(
+            reverse('delete_review', args=[self.review1.id]),
+        )
+
+        self.assertEqual(response.status_code, 302)  # ensure 302 Found status
+
+        # get messages from the request
+        messages = [m.message for m in get_messages(response.wsgi_request)]
+        self.assertEqual(str(messages[0]), 'Successfully deleted your review!')
+
+    def test_delete_nonexistent_review_id(self):
+        """Test if a 404 is returned for deleting a nonexistent review ID."""
+        self.client.force_login(self.user1)
+        response = self.client.post(
+            reverse('delete_review', args=[0])  # id 0 = nonexistent review
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_unauthorized_user_delete(self):
+        """Test if a 403 is returned for unauthorized review deletion."""
+        self.client.force_login(self.user2)  # force login as user2
+
+        # Note: because PermissionDenied is (should be) raised in this view, we get a really ugly
+        # traceback in the test runner. This isn't so nice, because it makes the
+        # `./precommit` output annoying to sort through.
+        # Is there any way to silence the errors while we're running tests?
+        response = self.client.post(
+            # try to delete review1, which is not authored by user2
+            reverse('delete_review', args=[self.review1.pk])
+        )
+
+        # trying to delete a review you don't have access to should result in
+        # 403 - forbidden
+        self.assertEqual(response.status_code, 403)

--- a/tcf_website/tests/test_review.py
+++ b/tcf_website/tests/test_review.py
@@ -99,7 +99,9 @@ class DeleteReviewTests(TestCase):
 
         # get messages from the request
         messages = [m.message for m in get_messages(response.wsgi_request)]
-        self.assertEqual(str(messages[0]), 'Successfully deleted your review!')
+        self.assertEqual(
+            str(messages[0]),
+            f'Successfully deleted your review for {str(self.review1.course)}!')
 
     @suppress_request_warnings
     def test_delete_nonexistent_review_id(self):

--- a/tcf_website/tests/test_review.py
+++ b/tcf_website/tests/test_review.py
@@ -118,10 +118,6 @@ class DeleteReviewTests(TestCase):
         """Test if a 403 is returned for unauthorized review deletion."""
         self.client.force_login(self.user2)  # force login as user2
 
-        # Note: because PermissionDenied is (should be) raised in this view, we get a really ugly
-        # traceback in the test runner. This isn't so nice, because it makes the
-        # `./precommit` output annoying to sort through.
-        # Is there any way to silence the errors while we're running tests?
         response = self.client.post(
             # try to delete review1, which is not authored by user2
             reverse('delete_review', args=[self.review1.pk])

--- a/tcf_website/views/review.py
+++ b/tcf_website/views/review.py
@@ -99,6 +99,7 @@ class DeleteReview(LoginRequiredMixin, generic.DeleteView):
 
         return super().delete(request, *args, **kwargs)
 
+
 @login_required
 def edit_review(request, review_id):
     """Review modification view."""
@@ -110,8 +111,9 @@ def edit_review(request, review_id):
         form = ReviewForm(request.POST, instance=review)
         if form.is_valid():
             form.save()
-            messages.success(request,
-                             f'Successfully updated your review for {form.instance.course}!')
+            messages.success(
+                request,
+                f'Successfully updated your review for {form.instance.course}!')
             return redirect('reviews')
         messages.error(request, form.errors)
         return render(request, 'reviews/edit_review.html', {'form': form})

--- a/tcf_website/views/review.py
+++ b/tcf_website/views/review.py
@@ -114,7 +114,6 @@ class DeleteReview(LoginRequiredMixin, generic.DeleteView):
     """Review deletion view."""
     model = Review
     success_url = reverse_lazy('reviews')
-    success_message = "Successfully deleted the review for %(course)s"
 
     def get_object(self):  # pylint: disable=arguments-differ
         """Override DeleteView's function to validate review belonging to user."""

--- a/tcf_website/views/review.py
+++ b/tcf_website/views/review.py
@@ -127,15 +127,11 @@ class DeleteReview(LoginRequiredMixin, generic.DeleteView):
     def delete(self, request, *args, **kwargs):
         """Overide DeleteView's delete function to add a message confirming deletion."""
         # Note: we don't use SuccessMessageMixin because it currently has issues
-        # with DeleteViews.
-        # See:
+        # with DeleteViews. See:
         # https://stackoverflow.com/questions/24822509/success-message-in-deleteview-not-shown
-        course = super().get_object().course
-
         messages.add_message(
             request,
             messages.SUCCESS,
-            'Successfully deleted the review for ' +
-            str(course) + '!')
+            'Successfully deleted your review!')
 
         return super().delete(request, *args, **kwargs)

--- a/tcf_website/views/review.py
+++ b/tcf_website/views/review.py
@@ -92,10 +92,14 @@ class DeleteReview(LoginRequiredMixin, generic.DeleteView):
         # Note: we don't use SuccessMessageMixin because it currently has issues
         # with DeleteViews. See:
         # https://stackoverflow.com/questions/24822509/success-message-in-deleteview-not-shown
+
+        # get the course this review is about
+        course = super().get_object().course
+
         messages.add_message(
             request,
             messages.SUCCESS,
-            'Successfully deleted your review!')
+            f'Successfully deleted your review for {str(course)}!')
 
         return super().delete(request, *args, **kwargs)
 

--- a/tcf_website/views/review.py
+++ b/tcf_website/views/review.py
@@ -114,6 +114,7 @@ class DeleteReview(LoginRequiredMixin, generic.DeleteView):
     """Review deletion view."""
     model = Review
     success_url = reverse_lazy('reviews')
+    success_message = "Successfully deleted the review for %(course)s"
 
     def get_object(self):  # pylint: disable=arguments-differ
         """Override DeleteView's function to validate review belonging to user."""
@@ -123,3 +124,19 @@ class DeleteReview(LoginRequiredMixin, generic.DeleteView):
             raise PermissionDenied(
                 "You are not allowed to delete this review!")
         return obj
+
+    def delete(self, request, *args, **kwargs):
+        """Overide DeleteView's delete function to add a message confirming deletion."""
+        # Note: we don't use SuccessMessageMixin because it currently has issues
+        # with DeleteViews.
+        # See:
+        # https://stackoverflow.com/questions/24822509/success-message-in-deleteview-not-shown
+        course = super().get_object().course
+
+        messages.add_message(
+            request,
+            messages.SUCCESS,
+            'Successfully deleted the review for ' +
+            str(course) + '!')
+
+        return super().delete(request, *args, **kwargs)


### PR DESCRIPTION
## Status
- Done

## GitHub Issues addressed (`#IssueNumber`)
- This PR closes #357 

## What I did
- Inspected code that adds message for newly created reviews in `views.new_review`
- Added override for generic `DeleteReview`'s `delete()` method. The override adds a message to the request, then invokes superclass `delete()` so that the review is properly deleted

## Screenshots
- Before: deleting a review leaves no message or confirmation
<img width="1440" alt="Screen Shot 2021-01-22 at 8 09 12 PM" src="https://user-images.githubusercontent.com/2716970/105563891-c65e3780-5ced-11eb-8fd8-6e462af76d9d.png">
- After: deleting a review leaves a banner-style message confirming successful deletion
<img width="1440" alt="Screen Shot 2021-01-22 at 8 09 30 PM" src="https://user-images.githubusercontent.com/2716970/105563897-d37b2680-5ced-11eb-83bb-186df5eb057e.png">

## Tests
Steps to test:
1. Create a new review
2. From the reviews page, delete your newly created review
3. Observe a message indicating your review has been deleted

## Questions/Discussions/Notes
- It would probably be most idiomatic to use [SuccessMessageMixin](https://docs.djangoproject.com/en/3.1/ref/contrib/messages/#django.contrib.messages.views.SuccessMessageMixin) from Django. I tried this, but [this StackOverflow issue](https://stackoverflow.com/questions/24822509/success-message-in-deleteview-not-shown) explains why that doesn't work.
- Is it appropriate code style to link to a StackOverflow issue in my code? It helps contextualize the choice I made, but it might also be a little clunky...

## Merging the PR
- Who should merge this PR?
  - [ ] I will merge it myself
  - [x] The last reviewer to approve can merge it
    - Should the commit history be preserved in the base branch, or is it okay to combine all of them into a single commit ("squash-merge")?
    - [ ] preserve the history
    - [x] squash-merge
