### PR TITLE
Yellow banner pops up when course not currently taught

### DIFF
--- a/tcf_website/views/browse.py
+++ b/tcf_website/views/browse.py
@@ -127,7 +127,7 @@ def course_view(request, mnemonic, course_number):
     if not currently_taught:
         messages.warning(
             request,
-            """Looks like this course isn\'t taught this semester. 
+            """Looks like this course isn\'t taught this semester.
             Sort by \"All\" in the top right to see previous semesters.""")
 
     return render(request, 'course/course.html',

--- a/tcf_website/views/browse.py
+++ b/tcf_website/views/browse.py
@@ -127,14 +127,15 @@ def course_view(request, mnemonic, course_number):
     if not currently_taught:
         messages.warning(
             request,
-            'Looks like this course isn\'t taught this semester. Sort by \"All\" in the top right to see previous semesters.')
+            """Looks like this course isn\'t taught this semester. 
+            Sort by \"All\" in the top right to see previous semesters.""")
 
     return render(request, 'course/course.html',
                   {
                       'course': course,
                       'instructors': instructors,
                       'latest_semester': latest_semester,
-                      'breadcrumbs': breadcrumbs,
+                      'breadcrumbs': breadcrumbs
                   })
 
 


### PR DESCRIPTION
## Status
- Done.

## GitHub Issues addressed (`#IssueNumber`)
- This PR closes #273 

## What I did
- Created a warning banner that pops up when a course is not being taught this semester.

## Screenshots
- Before
![image](https://user-images.githubusercontent.com/65180311/108113788-ef13eb80-7065-11eb-91e3-179a38c23eb0.png)

- After
![image](https://user-images.githubusercontent.com/65180311/108113772-e9b6a100-7065-11eb-978f-bb7a738e96ff.png)

## Tests
- A brief explanation of tests done/written or how reviewers can test your work
      - Go to a course that is not taught this semester (i.e. CS 4610) and verify that the banner appears.
      - Go to a course that is being taught this semester and verify that the banner does not appear.

## Questions/Discussions/Notes
- I'm thinking that having the banner at the top is not ideal but idk if it is possible to have a banner that isn't at the top.
- Possibly using a different color.

## Merging the PR
- Who should merge this PR?
  - [ ] I will merge it myself
  - [ ] The last reviewer to approve can merge it
- Should the commit history be preserved in the base branch, or is it okay to combine all of them into a single commit ("squash-merge")?
  - [ ] preserve the history
  - [ ] squash-merge
