### PR TITLE
Add discord notification for deployment

### DIFF
--- a/.github/workflows/master-to-app-engine.yml
+++ b/.github/workflows/master-to-app-engine.yml
@@ -81,6 +81,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Send a message to tCF Discord Server when deployment is finished
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_URL_CI }}
           DEPLOY_RESULT: ${{ needs.deploy.result }}

--- a/.github/workflows/master-to-app-engine.yml
+++ b/.github/workflows/master-to-app-engine.yml
@@ -74,3 +74,16 @@ jobs:
         uses: google-github-actions/deploy-appengine@main
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+  discord:
+    if: ${{ always() }}
+    needs: [deploy]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_URL_CI }}
+          DEPLOY_RESULT: ${{ needs.deploy.result }}
+        run: |
+          bash ./scripts/notify-deployment-result.sh
+        shell: bash

--- a/scripts/notify-deployment-result.sh
+++ b/scripts/notify-deployment-result.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+function get_content() {
+  repo_link="https://github.com/thecourseforum/theCourseForum2"
+  run_link="$repo_link/actions/runs/$GITHUB_RUN_ID"
+  if [ "$DEPLOY_RESULT" = "success" ]; then
+    echo "New deployment to https://thecourseforum.com/." \
+      "Click [here]($repo_link/commits/master) to see the most recent" \
+      "commits to \`master\`."
+  else
+    echo "Deployment failed. Click [here]($run_link) to see why."
+  fi
+}
+
+curl $DISCORD_WEBHOOK \
+  -X "POST" \
+  -H "Content-Type: application/json" \
+  -d "{ \"content\" : \"$(get_content)\" }"


### PR DESCRIPTION
## Status
- Done

## GitHub Issues addressed (`#IssueNumber`)
- This PR closes #387

## What I did
- Send a Discord notification when deployment is finished.

## Screenshots
- Before: None
- After: Depending on the result of the deployment, there will be two kinds of messages:
![image](https://user-images.githubusercontent.com/7676354/108612603-37117600-73b8-11eb-9442-a2c1afb32f47.png)

## Tests
- If you want to test it, assign the following variables at the top of the shell script:
```bash
GITHUB_RUN_ID="something"  # Click one from https://github.com/thecourseforum/theCourseForum2/actions if you want a legit link
DEPLOY_RESULT="success"  # or any other string if you want to test the failure case
DISCORD_WEBHOOK=""  # On our Discord server, go to #builds, click on `Edit Channel` - `Integrations` - `View Webhooks` - `GitHub Actions Bot` -` Copy Webhook URL`
```

## Questions/Discussions/Notes
- We'll actually test this on production on the first Sunday of March.

## Merging the PR
- Who should merge this PR?
  - [ ] I will merge it myself
  - [x] The last reviewer to approve can merge it
- Should the commit history be preserved in the base branch, or is it okay to combine all of them into a single commit ("squash-merge")?
  - [ ] preserve the history
  - [x] squash-merge
