### PR TITLE
Disable django-silk on Heroku/GAE

### DIFF
--- a/tcf_core/settings/__init__.py
+++ b/tcf_core/settings/__init__.py
@@ -17,9 +17,9 @@ def custom_recording_logic(request):
     return not request.path.startswith('/api')
 
 
+# Performance profiling for non-API views during development
 if os.environ.get('DJANGO_SETTINGS_MODULE') not in [
         'tcf_core.settings.dev', 'tcf_core.settings.prod']:
-    # Performance profiling for non-API views during development
     INSTALLED_APPS.append('silk')
     MIDDLEWARE.append('silk.middleware.SilkyMiddleware')
     SILKY_INTERCEPT_FUNC = custom_recording_logic

--- a/tcf_core/settings/__init__.py
+++ b/tcf_core/settings/__init__.py
@@ -17,7 +17,9 @@ def custom_recording_logic(request):
     return not request.path.startswith('/api')
 
 
-# Performance profiling for non-API views during development
-INSTALLED_APPS.append('silk')
-MIDDLEWARE.append('silk.middleware.SilkyMiddleware')
-SILKY_INTERCEPT_FUNC = custom_recording_logic
+if os.environ.get('DJANGO_SETTINGS_MODULE') not in [
+        'tcf_core.settings.dev', 'tcf_core.settings.prod']:
+    # Performance profiling for non-API views during development
+    INSTALLED_APPS.append('silk')
+    MIDDLEWARE.append('silk.middleware.SilkyMiddleware')
+    SILKY_INTERCEPT_FUNC = custom_recording_logic


### PR DESCRIPTION
## Status
- Done

## GitHub Issues addressed (`#IssueNumber`)
- This PR closes #411.

## What I did
- Moved silk-related code inside an `if` statement so that it doesn't get executed on Heroku or GAE.

## Screenshots
| Before | After |
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/7676354/109427364-16e94480-79c0-11eb-8a1b-d89b1418c5c5.png) | ![image](https://user-images.githubusercontent.com/7676354/109427475-a0007b80-79c0-11eb-9f78-0215bba8da57.png) |



## Tests
1. Run `docker exec -ti tcf_db psql tcf_db -U tcf_django` and then run `\dt` inside the PostgreSQL shell to verify that silk-related tables are there, just like in the screenshot.
2. Change the `if` statement to `if False:`
3. Run `docker exec -ti tcf_db psql tcf_db -U tcf_django` and then run `\dt` inside the PostgreSQL shell to verify that silk-related tables are gone. From this, we see that the `if` statement does something.
4. Now see `tcf_core/settings/prod.py`. Since we were able to modify `ALLOWED_HOSTS` the same way on GAE, we see that this PR will fix the issue.

## Questions/Discussions/Notes
- After this PR is merged to `master`, we should delete/truncate silk-related tables on prod to reduce the size of database dump. Right now, I uploaded a dump without some silk-related entries, which is 10 times smaller than the original.

## Merging the PR
- Who should merge this PR?
  - [ ] I will merge it myself
  - [x] The last reviewer to approve can merge it
  - Should the commit history be preserved in the base branch, or is it okay to combine all of them into a single commit ("squash-merge")?
    - [ ] preserve the history
    - [x] squash-merge
