### PR TITLE
Added reminder to add changes to wiki and made Markdown file lint-compliant

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,26 +1,35 @@
 ## Status
+
 - Done, In progress, etc
 
 ## GitHub Issues addressed
-- This PR closes 
+
+- This PR closes
 
 ## What I did
-- 
+
+-
 
 ## Screenshots
+
 - Before
 - After
 
 ## Tests
+
 - A brief explanation of tests done/written or how reviewers can test your work
 
 ## Questions/Discussions/Notes
-- 
+
+-
 
 ## Merging the PR
+
 - Who should merge this PR?
   - [ ] I will merge it myself
   - [ ] The last reviewer to approve can merge it
 - Should the commit history be preserved in the base branch, or is it okay to combine all of them into a single commit ("squash-merge")?
   - [ ] preserve the history
   - [ ] squash-merge
+
+## Add your changes to "Next Update" on the [release history page](https://github.com/thecourseforum/theCourseForum2/wiki/Release-History) once your PR gets merged!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,10 +26,10 @@
 ## Merging the PR
 
 - Who should merge this PR?
-  - [ ] I will merge it myself
-  - [ ] The last reviewer to approve can merge it
+  - [] I will merge it myself
+  - [] The last reviewer to approve can merge it
 - Should the commit history be preserved in the base branch, or is it okay to combine all of them into a single commit ("squash-merge")?
-  - [ ] preserve the history
-  - [ ] squash-merge
+  - [] preserve the history
+  - [] squash-merge
 
 ## Add your changes to "Next Update" on the [release history page](https://github.com/thecourseforum/theCourseForum2/wiki/Release-History) once your PR gets merged!


### PR DESCRIPTION
## Status
- Done

## GitHub Issues addressed
- This PR closes 

## What I did
- Changed the PR template to include a message telling people to add their changes to the [release history page](https://github.com/thecourseforum/theCourseForum2/wiki/Release-History) on the wiki. This is so exec members (i.e. me most of the time) don't have to go back and look at everything that got merged with every release to write them.

## Questions/Discussions/Notes
- 

## Merging the PR
- Who should merge this PR?
  - [ ] I will merge it myself
  - [x] The last reviewer to approve can merge it
- Should the commit history be preserved in the base branch, or is it okay to combine all of them into a single commit ("squash-merge")?
  - [ ] preserve the history
  - [x ] squash-merge
