### PR TITLE
Show newlines in reviews

### DIFF
--- a/tcf_website/templates/reviews/review.html
+++ b/tcf_website/templates/reviews/review.html
@@ -45,7 +45,7 @@
                   <div class="review-text-body collapse" id="reviewText{{review.id}}"
                      aria-expanded="false">
                      <!-- Full review text -->
-                    <p class="review-text-full">{{ review.text }}</p>
+                    <div class="review-text-full">{{ review.text|linebreaks }}</div>
                   </div>
                   <!-- Collapser link (click target spans entire row block) -->
                   <a role="button" class="review-collapse-link btn-block p-1 collapsed"


### PR DESCRIPTION
## Status

- Done

## GitHub Issues addressed

- This PR closes #486.

## What I did

- Added a [Django template filter](https://docs.djangoproject.com/en/3.1/ref/templates/builtins/#linebreaks) to show the hidden newlines

## Screenshots

- Before
![image](https://user-images.githubusercontent.com/7676354/116824191-ec01a500-ab56-11eb-9225-9479c702109a.png)

- After
![image](https://user-images.githubusercontent.com/7676354/116824198-f1f78600-ab56-11eb-9992-610b4091ccf2.png)

- Alternative
![image](https://user-images.githubusercontent.com/7676354/116824202-fa4fc100-ab56-11eb-8e70-40c2fc9578f1.png)

## Tests

1. Write a review containing multiple consecutive newlines
2. Check that it works on the course-instructor page and on the my reviews page.

## Questions/Discussions/Notes

- The consensus from the meeting was condensing multiple line breaks to one.

|number of newlines | number of reviews|
|:---:|---:|
|any|28687|
|0|26215|
|1|1019|
|2|1416|
|3|29|
|4|1|
|5|2|
|6-8|1|
|9 or more|4|

## Merging the PR

- Who should merge this PR?
  - [ ] I will merge it myself
  - [x] The last reviewer to approve can merge it
- Should the commit history be preserved in the base branch, or is it okay to combine all of them into a single commit ("squash-merge")?
  - [ ] preserve the history
  - [x] squash-merge

## Add your changes to "Next Update" on the [release history page](https://github.com/thecourseforum/theCourseForum2/wiki/Release-History) once your PR gets merged!
