### PR TITLE
Update package-lock.json for security reasons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -694,9 +694,9 @@
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "ignore": {
       "version": "4.0.6",
@@ -862,9 +862,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "minimatch": {
       "version": "3.0.4",


### PR DESCRIPTION
## Status

- Done

## GitHub Issues addressed

- This PR closes #494 and closes #495, the PRs that were created but `dependabot` but didn't pass the checks due to authentication failure.

## What I did

- Ran `npm audit fix` to fix packages that require security updates

## Screenshots
Not really a screenshot but a copy of my terminal output:
```
$docker exec -ti tcf_django bash
root@a6f6e8beb679:/app# npm i --package-lock-only
audited 179 packages in 4.891s

27 packages are looking for funding
  run `npm fund` for details

found 4 vulnerabilities (1 moderate, 3 high)
  run `npm audit fix` to fix them, or `npm audit` for details
root@a6f6e8beb679:/app# npm audit

                       === npm audit security report ===                        

# Run  npm update lodash --depth 3  to resolve 3 vulnerabilities
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Command Injection                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ eslint                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ eslint > @eslint/eslintrc > lodash                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1673                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Command Injection                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ eslint                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ eslint > lodash                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1673                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Command Injection                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ eslint                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ eslint > table > lodash                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1673                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


# Run  npm update hosted-git-info --depth 5  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ hosted-git-info                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ eslint-plugin-import                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ eslint-plugin-import > read-pkg-up > read-pkg >              │
│               │ normalize-package-data > hosted-git-info                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1677                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


found 4 vulnerabilities (1 moderate, 3 high) in 179 scanned packages
  run `npm audit fix` to fix 4 of them.
root@a6f6e8beb679:/app# npm audit fix
updated 2 packages in 15.227s

27 packages are looking for funding
  run `npm fund` for details       

fixed 4 of 4 vulnerabilities in 179 scanned packages
root@a6f6e8beb679:/app# 
```

## Tests

- N/A

## Questions/Discussions/Notes

- The dependabot's PRs will always fail, but I think it's nice to keep it since it notifies us of new security updates.
- I could have committed/pushed to #494 and #495, but I thought it would be better to explain everything in one place.
- If this doesn't close the two PRs, I'll have to close them myself.

## Merging the PR

- Who should merge this PR?
  - [ ] I will merge it myself
  - [x] The last reviewer to approve can merge it
- Should the commit history be preserved in the base branch, or is it okay to combine all of them into a single commit ("squash-merge")?
  - [ ] preserve the history
  - [x] squash-merge

## Add your changes to "Next Update" on the [release history page](https://github.com/thecourseforum/theCourseForum2/wiki/Release-History) once your PR gets merged!
