### PR TITLE
Swap emoji order of recommendability and difficulty

### DIFF
--- a/tcf_website/templates/reviews/review.html
+++ b/tcf_website/templates/reviews/review.html
@@ -91,13 +91,13 @@
                             <i class="far fa-smile-beam"></i>
                             {{ review.enjoyability }}
                         </div>
-                        <div class="mr-3 mr-sm-4" data-toggle="tooltip" data-placement="bottom" title="Difficulty">
-                            <i class="fa fa-dumbbell fa-fw"></i>
-                            {{ review.difficulty }}
-                        </div>
                         <div class="mr-3 mr-sm-4"   data-toggle="tooltip" data-placement="bottom" title="Recommend">
                             <i class="fas fa-heart"></i>
                             {{ review.recommendability }}
+                        </div>
+                        <div class="mr-3 mr-sm-4" data-toggle="tooltip" data-placement="bottom" title="Difficulty">
+                            <i class="fa fa-dumbbell fa-fw"></i>
+                            {{ review.difficulty }}
                         </div>
                         <div data-toggle="tooltip" data-placement="bottom" title="Hours Per Week">
                             <i class="fa fa-hourglass-half fa-fw"></i>

--- a/tcf_website/templates/reviews/review_form_content.html
+++ b/tcf_website/templates/reviews/review_form_content.html
@@ -95,24 +95,6 @@
           </div>
       </div>
       <div class="mt-3">
-          <label for="difficulty" class="m-0">
-            <i class="fas fa-dumbbell"></i> Difficulty
-          </label>
-          <div class="row">
-              <div class="col-xl-9 col-8 py-2">
-                <input type="range" class="custom-range"
-                       min="1" max="5" step="1" value="{{ form.difficulty.value|default:3 }}"
-                       id="difficulty" name="difficulty" required>
-              </div>
-              <div class="col-xl-3 col-4 pl-lg-2 pl-0 d-inline-flex">
-                <input type="number" class="form-control text-center"
-                       min="1" max="5" value="{{ form.difficulty.value|default:3 }}"
-                       id="difficulty2" name="difficulty2" required>
-                <span class="ml-2 mt-2">/5</span>
-              </div>
-          </div>
-      </div>
-      <div class="mt-3">
           <label for="recommendability" class="m-0">
             <i class="fas fa-heart"></i> Recommend
           </label>
@@ -126,6 +108,24 @@
                 <input type="number" class="form-control text-center"
                        min="1" max="5" value="{{ form.recommendability.value|default:3 }}"
                        id="recommendability2" name="recommendability2" required>
+                <span class="ml-2 mt-2">/5</span>
+              </div>
+          </div>
+      </div>
+      <div class="mt-3">
+          <label for="difficulty" class="m-0">
+            <i class="fas fa-dumbbell"></i> Difficulty
+          </label>
+          <div class="row">
+              <div class="col-xl-9 col-8 py-2">
+                <input type="range" class="custom-range"
+                       min="1" max="5" step="1" value="{{ form.difficulty.value|default:3 }}"
+                       id="difficulty" name="difficulty" required>
+              </div>
+              <div class="col-xl-3 col-4 pl-lg-2 pl-0 d-inline-flex">
+                <input type="number" class="form-control text-center"
+                       min="1" max="5" value="{{ form.difficulty.value|default:3 }}"
+                       id="difficulty2" name="difficulty2" required>
                 <span class="ml-2 mt-2">/5</span>
               </div>
           </div>


### PR DESCRIPTION
## Status
Done

## GitHub Issues addressed

- This PR closes #500 

## What I did

- Swapped the emoji order of "Recommend" and "Difficulty" so that "Recommend" comes first on both the review page and the review card of a given review.

## Screenshots

- Before
<img width="533" alt="Screen Shot 2021-05-18 at 2 31 42 PM" src="https://user-images.githubusercontent.com/26678709/118706026-e6f35580-b7e6-11eb-8da1-10714fed00be.png">
<img width="1150" alt="Screen Shot 2021-05-18 at 2 32 24 PM" src="https://user-images.githubusercontent.com/26678709/118706031-e9ee4600-b7e6-11eb-8d78-28d9d8a68c5d.png">

- After
<img width="536" alt="Screen Shot 2021-05-18 at 2 28 35 PM" src="https://user-images.githubusercontent.com/26678709/118706080-f377ae00-b7e6-11eb-8bc8-5f8c7a88dc7f.png">
<img width="1160" alt="Screen Shot 2021-05-18 at 2 28 29 PM" src="https://user-images.githubusercontent.com/26678709/118706087-f5417180-b7e6-11eb-9f48-cd88f56d8118.png">


## Tests

- Really not a significant change. Just ensure that the "Recommend" emoji comes before the "Difficulty" emoji in all relevant places (i.e. when writing a new review, the review card for a given course, etc.).

## Questions/Discussions/Notes
- The two files I changed were the only places I think the emojis appear/there is any order. Let me know if there are other places the emoji order should change too that I missed.

## Merging the PR

- Who should merge this PR?
  - [] I will merge it myself
  - [x] The last reviewer to approve can merge it
- Should the commit history be preserved in the base branch, or is it okay to combine all of them into a single commit ("squash-merge")?
  - [] preserve the history
  - [x] squash-merge

## Add your changes to "Next Update" on the [release history page](https://github.com/thecourseforum/theCourseForum2/wiki/Release-History) once your PR gets merged!
