### PR TITLE
Remove fall 2021 review drive banner

### DIFF
--- a/tcf_website/templates/browse/browse.html
+++ b/tcf_website/templates/browse/browse.html
@@ -12,8 +12,10 @@
         {% include "../common/notification.html" %}
     </div> {% endcomment %}
     <div class="browse container">
+        {% comment %}
         {% include "../common/review-drive-banner.html" %}
-        <br/>
+        <br />
+        {% endcomment %}
         {% include "../common/leaderboard_ad.html" with ad_slot="9691204298" %}
 
         <!-- Browse page content -->


### PR DESCRIPTION
## Status

Done

## GitHub Issues addressed

No issue was created.

## What I did

Commented out the part of the [browse template](./tcf_website/templates/browse/browse.html) containing the review drive banner.

## Screenshots
**Before**
<img width="1130" alt="image" src="https://user-images.githubusercontent.com/2716970/148271824-a46d09c3-5f6a-4668-85e4-a8eed8344c59.png">

**After**
<img width="1179" alt="image" src="https://user-images.githubusercontent.com/2716970/148271847-0a322ee6-e8a0-4fa9-a07a-ac19cfced299.png">
(I swear, I turned off my adblock for you guys, I have no idea why the ads are blank)

## Tests

N/A

## Questions/Discussions/Notes

## Merging the PR

- Who should merge this PR?
  - [ ] I will merge it myself
  - [X] The last reviewer to approve can merge it
- Should the commit history be preserved in the base branch, or is it okay to combine all of them into a single commit ("squash-merge")?
  - [X] preserve the history
  - [ ] squash-merge

## Add your changes to "Next Update" on the [release history page](https://github.com/thecourseforum/theCourseForum2/wiki/Release-History) once your PR gets merged!
