### PR TITLE
Fix #557: deleting reviews does not show message causing test failure

### DIFF
--- a/tcf_website/views/review.py
+++ b/tcf_website/views/review.py
@@ -4,6 +4,7 @@ from django import forms
 from django.views import generic
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin  # For class-based views
+from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import PermissionDenied
 from django.contrib import messages
 from django.http import JsonResponse
@@ -151,7 +152,7 @@ def check_zero_hours_per_week(request):
 # Note: Class-based views can't use the @login_required decorator
 
 
-class DeleteReview(LoginRequiredMixin, generic.DeleteView):
+class DeleteReview(LoginRequiredMixin, SuccessMessageMixin, generic.DeleteView):
     """Review deletion view."""
     model = Review
     success_url = reverse_lazy('reviews')
@@ -165,21 +166,13 @@ class DeleteReview(LoginRequiredMixin, generic.DeleteView):
                 "You are not allowed to delete this review!")
         return obj
 
-    def delete(self, request, *args, **kwargs):
-        """Overide DeleteView's delete function to add a message confirming deletion."""
-        # Note: we don't use SuccessMessageMixin because it currently has issues
-        # with DeleteViews. See:
-        # https://stackoverflow.com/questions/24822509/success-message-in-deleteview-not-shown
-
+    def get_success_message(self, cleaned_data) -> str:
+        """Overrides SuccessMessageMixin's get_success_message method."""
         # get the course this review is about
-        course = super().get_object().course
+        course = self.object.course
 
-        messages.add_message(
-            request,
-            messages.SUCCESS,
-            f'Successfully deleted your review for {str(course)}!')
-
-        return super().delete(request, *args, **kwargs)
+        # return success message
+        return f"Successfully deleted your review for {str(course)}!"
 
 
 @login_required


### PR DESCRIPTION
## Status

Done

## GitHub Issues addressed

Fixes #557 

## What I did

Refactored the `DeleteReview` view to use Django's `SuccessMessageMixin` for success messages.

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/2716970/148276735-d1a3f6af-8181-45d9-99a4-507792f59ab2.png)

After:
<img width="1323" alt="image" src="https://user-images.githubusercontent.com/2716970/148276759-50d5a5d0-9f71-4a0d-95fa-aa7bed01eec2.png">


## Tests

Fixes failing test `test_delete_review_message`.

## Questions/Discussions/Notes

Incidentally, [my first PR](https://github.com/thecourseforum/theCourseForum2/pull/359) was adding a message for review deletion. At the time, an issue with the `SuccessMessageMixin` meant that it was incompatible with `DeleteView`. At the time your best workaround was to override the `delete` method and add your own messaging logic.

Since then, Django has reimplemented `DeleteView` to use `FormMixin` behind the scenes. This rendered my workaround obsolete, as the obvious way [to implement success messages](https://docs.djangoproject.com/en/4.0/ref/contrib/messages/#django.contrib.messages.views.SuccessMessageMixin) now works with `DeleteView`s.

## Merging the PR

- Who should merge this PR?
  - [] I will merge it myself
  - [x] The last reviewer to approve can merge it
- Should the commit history be preserved in the base branch, or is it okay to combine all of them into a single commit ("squash-merge")?
  - [x] preserve the history
  - [] squash-merge

