### PR TITLE
Review autofill from course instructor page

### DIFF
--- a/tcf_website/static/reviews/new_review.js
+++ b/tcf_website/static/reviews/new_review.js
@@ -13,6 +13,21 @@ jQuery(function($) {
     clearDropdown("#instructor");
     clearDropdown("#semester");
 
+    // If coming from sidebar:
+    // Path will be /reviews/new
+    //    => path = ['', 'reviews', 'new']
+
+    // If coming from course instructor page (autofill):
+    // Path will be /reviews/new/subdept/subdepartment_id/course/course_id/instr/instructor_id
+    //    => path = ['', 'reviews', 'new', 'subdept', subdepartment_id, 'course', course_id, 'instr', instructor_id]
+    const path = window.location.pathname.split("/");
+    let subdeptID, courseID, instructorID;
+    if (path.length > 3) {
+        subdeptID = parseInt(path[4]);
+        courseID = parseInt(path[6]);
+        instructorID = parseInt(path[8]);
+    }
+
     // Fetch all subdepartment data from API
     var subdeptEndpoint = "/api/subdepartments/";
     $.getJSON(subdeptEndpoint, function(data) {
@@ -25,8 +40,14 @@ jQuery(function($) {
         $.each(data, function(i, subdept) {
             $("<option />", {
                 val: subdept.id,
-                text: subdept.mnemonic + " | " + subdept.name
+                text: subdept.mnemonic + " | " + subdept.name,
+                // Check for autofill
+                selected: subdept.id === subdeptID
             }).appendTo("#subject");
+            // Trigger change on autofill
+            if (subdept.id === subdeptID) {
+                $("#subject").trigger("change");
+            }
         });
         return this;
     })
@@ -55,8 +76,14 @@ jQuery(function($) {
             $.each(data.results, function(i, course) {
                 $("<option />", {
                     val: course.id,
-                    text: course.number + " | " + course.title
+                    text: course.number + " | " + course.title,
+                    // Check for autofill
+                    selected: course.id === courseID
                 }).appendTo("#course");
+                // Trigger change on autofill
+                if (course.id === courseID) {
+                    $("#course").trigger("change");
+                }
             });
             return this;
         })
@@ -86,8 +113,14 @@ jQuery(function($) {
             $.each(data.results, function(i, instr) {
                 $("<option />", {
                     val: instr.id,
-                    text: instr.last_name + ", " + instr.first_name
+                    text: instr.last_name + ", " + instr.first_name,
+                    // Check for autofill
+                    selected: instr.id === instructorID
                 }).appendTo("#instructor");
+                // Trigger change on autofill
+                if (instr.id === instructorID) {
+                    $("#instructor").trigger("change");
+                }
             });
             return this;
         })

--- a/tcf_website/templates/course/course_professor.html
+++ b/tcf_website/templates/course/course_professor.html
@@ -13,7 +13,7 @@
         {% include "../common/leaderboard_ad.html" with ad_slot="5402759869" %}
         <!-- Empty div for margin (maybe not the best solution) -->
         <div class="mt-4"></div>
-        
+
         {% include "common/toolbar.html" with breadcrumbs=breadcrumbs %}
 
         <div class="course-instructor-header my-2">
@@ -198,7 +198,7 @@
             <div class="reviews-toolbar pb-2 d-flex flex-md-row flex-column justify-content-left justify-content-md-center">
                 <h3 class="reviews-heading mb-0 mt-1 mr-4">{{ reviews|length }} {% if reviews|length == 1 %} Comment {% else %} Comments {% endif %}</h3>
                 <div class="reviews-options d-flex flex-sm-row flex-column col p-0">
-                    <a href="{% url 'new_review' %}" class="btn bg-tcf-orange text-white mb-3">
+                    <a href="{% url 'new_review_auto' subdepartment_id=course.subdepartment.id course_id=course.id instructor_id=instructor.id %}" class="btn bg-tcf-orange text-white mb-3">
                       <i class="fa fa-plus" aria-hidden="true"></i> Add your review!
                     </a>
                     {% if reviews %}

--- a/tcf_website/urls.py
+++ b/tcf_website/urls.py
@@ -1,4 +1,5 @@
 """Routes URLs to views"""
+# pylint: disable=line-too-long
 
 from django.urls import include, path
 
@@ -20,6 +21,10 @@ urlpatterns = [
     path('instructor/<int:instructor_id>',
          views.instructor_view, name='instructor'),
     path('reviews/new', views.new_review, name='new_review'),
+    path(
+        'reviews/new/subdept/<int:subdepartment_id>/course/<int:course_id>/instr/<int:instructor_id>',
+        views.new_review,
+        name='new_review_auto'),
     path('reviews/<int:pk>/delete',
          views.DeleteReview.as_view(), name='delete_review'),
     path('reviews/<int:review_id>/edit',

--- a/tcf_website/views/review.py
+++ b/tcf_website/views/review.py
@@ -62,8 +62,9 @@ def downvote(request, review_id):
 
 
 @login_required
-def new_review(request):
+def new_review(request, subdepartment_id=None, course_id=None, instructor_id=None):
     """Review creation view."""
+    print(subdepartment_id, course_id, instructor_id)
 
     # Collect form data into Review model instance.
     if request.method == 'POST':


### PR DESCRIPTION
## Status

- Done

## GitHub Issues addressed

- This PR closes #156

## What I did

- Created new path to the `new_review()` view in order to pass query params (subdepartment_id, course_id, instructor_id) needed to autofill the review form
- Updated the `course_professor.html` template to utilize this new url path when the "Add your review!" button is pressed
- Updated the jQuery in `new_review.js` that populated the select field options in the form, auto-selecting the options matching the query params (if applicable)

## Screenshots

- Before

![image](https://user-images.githubusercontent.com/59891647/151720373-dd603d81-6cf8-480a-afa5-bf321fdf2a7c.png)

- After (note the url path)

![image](https://user-images.githubusercontent.com/59891647/151720392-25745f54-ab3e-4fde-be29-548335f90d3d.png)

## Tests

- After pull, navigate to any course instructor page and click the "Add your review!" button. The review form should have the Subject, Course, and Instructor fields autofilled.

## Questions/Discussions/Notes

- Did not autofill semester, as people are allowed to review instructors for classes taught in past semesters.

## Merging the PR

- Who should merge this PR?
  - [] I will merge it myself
  - [x] The last reviewer to approve can merge it
- Should the commit history be preserved in the base branch, or is it okay to combine all of them into a single commit ("squash-merge")?
  - [] preserve the history
  - [] squash-merge

## Add your changes to "Next Update" on the [release history page](https://github.com/thecourseforum/theCourseForum2/wiki/Release-History) once your PR gets merged!
