### PR TITLE
Fix pylint

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,6 +10,7 @@ on:
     branches: [dev, master]
 env:
   PYTHON_TARGET: 3.9
+  PYTHONPATH: /app # Needed for pylint to work; should be root directory of app
   # Django
   DJANGO_SETTINGS_MODULE: tcf_core.settings.ci
   SECRET_KEY: ${{ secrets.SECRET_KEY }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run pylint
         run: |
-          echo "::set-env name=PYTHONPATH::home/runner/work/theCourseForum2"
+          export PYTHONPATH="$(pwd)"
           pylint --django-settings-module=${{ env.DJANGO_SETTINGS_MODULE }} --jobs=0 --load-plugins pylint_django tcf_website tcf_core
 
   django:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,7 +10,6 @@ on:
     branches: [dev, master]
 env:
   PYTHON_TARGET: 3.9
-  PYTHONPATH: /app # Needed for pylint to work; should be root directory of app
   # Django
   DJANGO_SETTINGS_MODULE: tcf_core.settings.ci
   SECRET_KEY: ${{ secrets.SECRET_KEY }}
@@ -49,7 +48,9 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run pylint
-        run: pylint --django-settings-module=${{ env.DJANGO_SETTINGS_MODULE }} --jobs=0 --load-plugins pylint_django tcf_website tcf_core
+        run: |
+          echo "::set-env name=PYTHONPATH::home/runner/work/theCourseForum2"
+          pylint --django-settings-module=${{ env.DJANGO_SETTINGS_MODULE }} --jobs=0 --load-plugins pylint_django tcf_website tcf_core
 
   django:
     runs-on: ubuntu-latest

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,3 @@
+[MAIN]
+
+ignore=migrations

--- a/tcf_website/api/filters.py
+++ b/tcf_website/api/filters.py
@@ -2,7 +2,7 @@
 from django_filters import FilterSet, NumberFilter
 from ..models import Instructor, Semester
 
-# pylint: disable=unused-argument,no-self-use
+# pylint: disable=unused-argument
 
 
 class InstructorFilter(FilterSet):

--- a/tcf_website/api/serializers.py
+++ b/tcf_website/api/serializers.py
@@ -1,4 +1,3 @@
-# pylint: disable=no-self-use
 """DRF Serializers"""
 from rest_framework import serializers
 from ..models import (Course, Department, School, Instructor, Semester,

--- a/tcf_website/views/discord.py
+++ b/tcf_website/views/discord.py
@@ -15,6 +15,6 @@ def post_message(query):
     content = {'content': query.GET.get("content", "")}
     json_data = json.dumps(content)
     requests.post(
-        url, data=json_data, headers={
+        url, data=json_data, timeout=5, headers={
             "Content-Type": "application/json"})
     return JsonResponse(content)

--- a/tcf_website/views/search.py
+++ b/tcf_website/views/search.py
@@ -52,7 +52,8 @@ def fetch_elasticsearch(api_endpoint, algorithm):
         response = requests.get(
             url=api_endpoint,
             headers=https_headers,
-            params=algorithm
+            params=algorithm,
+            timeout=5
         )
         if response.status_code != 200:
             response = {


### PR DESCRIPTION
Pylint is broken on all new builds because `PYTHONPATH` isn't set. Not sure why it isn't being set when it's worked for 2 years, but I'm setting it manually. Also needed to fix a few things to make Pylint compliance back to 10/10.