### PR TITLE
Add linked-in icon for D&M and links open in new tab

### DIFF
--- a/tcf_website/templates/about/current_team.html
+++ b/tcf_website/templates/about/current_team.html
@@ -67,9 +67,11 @@
                     <h5 class="card-text">{{ member.name }}</h5>
                     <p class="card-text small text-muted">Class of {{ member.class }}</p>
                   </span>
-                  <a class="text-muted" href="https://github.com/{{ member.github }}">
+                  {% if member.github %}
+                  <a class="text-muted" href="https://github.com/{{ member.github }}" target="_blank">
                     <h4><i class="fa fa-github"></i></h4>
                   </a>
+                  {% endif %}
                 </div>
               </div>
             </div>
@@ -89,9 +91,16 @@
                 <div class="pfp">
                   <img class="card-img-top" src="{% static 'about/team-pfps/'|add:member.img_filename %}" alt="{{ member.name }}">
                 </div>
-                <div class="card-body">
-                  <h5 class="card-text">{{ member.name }}</h5>
-                  <p class="card-text small text-muted">Class of {{ member.class }}</p>
+                <div class="card-body d-flex justify-content-between">
+                  <span>
+                    <h5 class="card-text">{{ member.name }}</h5>
+                    <p class="card-text small text-muted">Class of {{ member.class }}</p>
+                  </span>
+                  {% if member.linkedin %}
+                  <a class="text-muted" href="https://linkedin.com/in/{{ member.linkedin }}" target="_blank">
+                    <h4><i class="fa fa-linkedin"></i></h4>
+                  </a>
+                  {% endif %}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Status

- Done

## GitHub Issues addressed

- This PR closes #548

## What I did

- Added linked-in field to team info json and changed current team HTML file to add linked-in icon and open a new page when clicked (if the person added their linked in)
- also ensured all icons open to new tab in about

## Screenshots

- Before
<img width="1136" alt="Screen Shot 2022-10-15 at 3 12 16 PM" src="https://user-images.githubusercontent.com/47765531/196004208-0f358930-8939-42ee-aaa6-5844caed81b6.png">

- After
<img width="1136" alt="Screen Shot 2022-10-15 at 3 11 34 PM" src="https://user-images.githubusercontent.com/47765531/196004206-6b5dc44e-970d-4193-9d7f-c15c98410864.png">

## Tests

- Loading about page

## Questions/Discussions/Notes

- Was opening links in new tab good? Any other changes?

## Merging the PR

- Who should merge this PR?
  - [ ] I will merge it myself
  - [X] The last reviewer to approve can merge it
- Should the commit history be preserved in the base branch, or is it okay to combine all of them into a single commit ("squash-merge")?
  - [ ] preserve the history
  - [ ] squash-merge

## Add your changes to "Next Update" on the [release history page](https://github.com/thecourseforum/theCourseForum2/wiki/Release-History) once your PR gets merged!
