### PR TITLE
match pep8 formatting to pre-commit hook

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pep8]
+max-line-length=100


### PR DESCRIPTION
## Status

- Done

## GitHub Issues addressed

- Currently the [pre-commit hook](https://github.com/thecourseforum/theCourseForum2/blob/be96c761af0d9f5bb2864e2dee7f2d77ee5a833d/precommit.sh#L11) formats with line width 100 which clashes with many formatter defaults. Now format-on-save in most traditional editors will match the actual committed code.

## What I did

- Create simple `setup.cfg` to configure autopep8 with max-width 100 (instead of the default 80)
