### PR TITLE
Blog post rendering

### DIFF
--- a/tcf_website/static/blog/blog.css
+++ b/tcf_website/static/blog/blog.css
@@ -20,5 +20,5 @@
 }
 .blog-body blockquote {
   border-left: 1px solid #6c757d;
-  padding: 1em;
+  padding: 0 0.9em;
 }

--- a/tcf_website/static/blog/blog.css
+++ b/tcf_website/static/blog/blog.css
@@ -1,3 +1,7 @@
+.col {
+  max-width: 670px;
+  margin: auto;
+}
 .blog-body a {
   text-decoration: underline;
 }

--- a/tcf_website/static/blog/blog.css
+++ b/tcf_website/static/blog/blog.css
@@ -1,6 +1,7 @@
 .col {
   max-width: 670px;
   margin: auto;
+  text-align: left;
 }
 .blog-body a {
   text-decoration: underline;

--- a/tcf_website/static/blog/blog.css
+++ b/tcf_website/static/blog/blog.css
@@ -18,3 +18,7 @@
   background-color: #f0f0f0;
   padding: 0.2em;
 }
+.blog-body blockquote {
+  border-left: 1px solid #6c757d;
+  padding: 1em;
+}

--- a/tcf_website/templates/blog/post.html
+++ b/tcf_website/templates/blog/post.html
@@ -26,7 +26,7 @@ theCourseForum{% endblock %} {% block styles %}
         <div class="row mt-4 p-4 bg-light">
             <div class="col">
                 <p class="text-muted">
-                    Written by: {{post_detail.author}} &#8226; {{ post_detail.created_date | date:"N d, Y" }}</span>
+                    Written by {{post_detail.author}} &#8226; {{ post_detail.created_date | date:"N d, Y" }}</span>
                 </p>
                 <h1 class="display-3">{{ post_detail.title }}</h1>
                 <h2 class="text-muted">{{ post_detail.subtitle }}</h2>

--- a/tcf_website/templates/blog/post.html
+++ b/tcf_website/templates/blog/post.html
@@ -1,7 +1,13 @@
-{% extends "base/base.html" %} {% load static %} {% block title %}theBlog -
-theCourseForum{% endblock %} {% block styles %}
+{% extends "base/base.html" %} 
+{% load static %} 
+
+{% block title %}theBlog - theCourseForum{% endblock %}
+
+{% block styles %}
 <link rel="stylesheet" href="{% static 'blog/blog.css' %}" />
-{% endblock %} {% block content %}
+{% endblock %} 
+
+{% block content %}
 <!-- {% comment %} <div class="container">
         {% include "../common/notification.html" %}
     </div> {% endcomment %} -->
@@ -15,13 +21,13 @@ theCourseForum{% endblock %} {% block styles %}
     <!-- Browse page content -->
     <section id="masthead">
         <div class="row px-5 py-3 bg-tcf-orange text-white">
-          <div class="col-sm-6">
-            <a href="{% url 'blog' %}" class="link-unstyled">
-              <h2 class="display-4 font-weight-bold mb-2">theBlog</h2>
-            </a>
-          </div>
+            <div class="col-sm-6">
+                <a href="{% url 'blog' %}" class="link-unstyled">
+                    <h2 class="display-4 font-weight-bold mb-2">theBlog</h2>
+                </a>
+            </div>
         </div>
-      </section>    
+    </section>
     <section>
         <div class="row mt-4 p-4 bg-light">
             <div class="col">


### PR DESCRIPTION
## GitHub Issues addressed

- This PR closes #562 

## What I did

- Edited blog post formatting/rendering

## Screenshots

- Before
<img width="1401" alt="Screen Shot 2022-12-17 at 8 45 58 PM" src="https://user-images.githubusercontent.com/62630715/208275152-da8ed6b8-1087-408a-b3a0-794507d9c5bd.png">
<img width="1400" alt="Screen Shot 2022-12-17 at 8 46 09 PM" src="https://user-images.githubusercontent.com/62630715/208275185-a9d7ab83-4e61-4a60-a758-e3715db8e6cd.png">
<img width="308" alt="Screen Shot 2022-12-17 at 8 46 29 PM" src="https://user-images.githubusercontent.com/62630715/208275249-c3550ba3-037b-4937-a958-d90dcc556ab6.png">

- After
<img width="1401" alt="Screen Shot 2022-12-17 at 8 41 15 PM" src="https://user-images.githubusercontent.com/62630715/208274225-08a2e267-0c86-44e7-a489-d0f483745121.png">
<img width="1401" alt="Screen Shot 2022-12-17 at 8 44 10 PM" src="https://user-images.githubusercontent.com/62630715/208274798-5a70675c-2740-4537-b22b-6eaf120d3a3a.png">
<img width="308" alt="Screen Shot 2022-12-17 at 8 45 05 PM" src="https://user-images.githubusercontent.com/62630715/208274985-c301a5f0-9788-414d-ba93-7d2041766983.png">


## Testing

- Create a post

## Questions/Discussions/Notes

- There are some things that were listed in the [github md](https://github.com/adamschwartz/github-markdown-kitchen-sink/blob/master/TEST.md) that don't get recognized by markdownify. I don't think this is too big of an issue though because they can be easily recreated by other methods. For example, `- - -` doesn't get recognized, but `* * *` can be used instead. If this is an issue I can try to fix it, but then this evolves beyond a CSS issue.
