### PR TITLE
readme facelift

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,32 @@
-![version](https://img.shields.io/badge/version-1.0.0-blue.svg) [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-[![Build Status](https://github.com/thecourseforum/theCourseForum2/workflows/Continuous%20Integration/badge.svg?branch=master)](https://github.com/thecourseforum/theCourseForum2/actions?query=workflow%3A%22Continuous+Integration%22+branch%3Amaster) [![GitHub issues open](https://img.shields.io/github/issues/thecourseforum/theCourseForum2.svg?maxAge=2592000)]() [![GitHub issues closed](https://img.shields.io/github/issues-closed-raw/thecourseforum/theCourseForum2.svg?maxAge=2592000)]()
+<p align="center">
+    <img src="./tcf_website/static/base/img/new_logo.png" alt="logo" width="200"/>
+</p>
 
-2020 Django rewrite of [theCourseForum 1.0](https://github.com/thecourseforum/theCourseForum) website at [thecourseforum.com](https://thecourseforum.com/).
+<h1 align="center">theCourseForum2</h1>
 
-# theCourseForum2
- 
-### Connecting University of Virginia Students to Course Information and Reviews
+<p align="center">
+    <img alt="version" src="https://img.shields.io/badge/version-1.0.0-blue.svg" />
+    <a href="https://www.gnu.org/licenses/gpl-3.0" target="_blank"><img alt="License: GPL v3" src="https://img.shields.io/badge/License-GPLv3-blue.svg" /></a>
+    <a href="https://github.com/thecourseforum/theCourseForum2/actions?query=workflow%3A%22Continuous+Integration%22+branch%3Amaster"><img src="https://github.com/thecourseforum/theCourseForum2/workflows/Continuous%20Integration/badge.svg?branch=master" /></a>
+    <a href="https://github.com/thecourseforum/theCourseForum2/issues"><img alt="issues" src="https://img.shields.io/github/issues/thecourseforum/theCourseForum2.svg?maxAge=2592000)" /></a>
+</p>
 
+<p align="center">
+Connecting University of Virginia students to course information and reviews
+</p>
 
-### About
-theCourseForum was created by students for students. We gather freely available information to help students evaluate their course options at the University. Students in turn then review courses in their own words for others to help others.
+> 2020 Django rewrite of [theCourseForum 1.0](https://github.com/thecourseforum/theCourseForum) website at [theCourseForum.com](https://thecourseforum.com/).
+
+## About
+
+_theCourseForum_ was created by students for students. We gather freely available information to help students evaluate their course options. Students in turn then review courses in their own words for others to help others.
 
 Started 15 years ago, the project has grown monumentally. Over 10k users in the UVA student body uses the website each and every semester. We gather data and other information in an effort to help students better select classes. The source code in this repository is the third major version of the website.
 
-theCourseForum team is a group of students that contribute their time and effort to continue to improve the site for other students to use.
+_theCourseForum_ team is a group of students that contribute their time and effort to continue to improve the site for other students to use.
 
-### Stack
+## Stack
+
 The code stack is current standard technologies. They were chosen because they are robust and align with the stack that UVA students learn in courses.
 
 - Python
@@ -24,5 +35,6 @@ The code stack is current standard technologies. They were chosen because they a
 - Bootstrap 4
 - Javascript (jQuery)
 
-### Want to get involved?
-Don't hesitate to contact us whether or not that you are at the University of Virginia! We love to talk about our app and we love to discuss everything that we do! Join our [Discord server](https://discord.com/invite/tAjzH7eyvW) or shoot us an email at info@thecourseforum.com.
+## Want to get involved?
+
+Don't hesitate to contact us whether or not that you are at the University of Virginia! We love to talk about our app and we love to discuss everything that we do! Join our [Discord server](https://discord.com/invite/tAjzH7eyvW) or shoot us an email at [info@thecourseforum.com](mailto:info@thecourseforum.com).


### PR DESCRIPTION
## What I did

Made some stylistic changes to the README.md

## Screenshots

- Before

<img width="685" alt="Screenshot 2023-09-24 at 11 37 36 PM" src="https://github.com/thecourseforum/theCourseForum2/assets/27795014/38e1fdc2-6997-4635-b8ca-0fed0d17e8de">

- After

<img width="650" alt="Screenshot 2023-09-24 at 11 37 04 PM" src="https://github.com/thecourseforum/theCourseForum2/assets/27795014/2bc2fd7e-b9b9-4d12-9ee0-ff51669485dc">

## Questions/Discussions/Notes

- *theCourseForum* should be italicized since it is a name. 
- the number of closed issues is not the most relevant thing to a project. 
- `###` should not be used as the headings for a page have a particular meanings for accessibility rather than simply the side of text
- centered things look better
- adding a logo to the top helps with brand recognition 

---

Note: there is already a pull request #679 which I created and @barrett-ruth  commented on. I messed up my commit history and forgot branching (I was being lazy). This PR fixes this with squashed commits and a proper branch.