### PR TITLE
remove extra quote in review-redirect

### DIFF
--- a/tcf_website/templates/course/course_professor.html
+++ b/tcf_website/templates/course/course_professor.html
@@ -264,7 +264,7 @@
                         <h3 class="reviews-heading mb-0 mt-1 mr-4">{{ reviews|length }} {% if reviews|length == 1 %} Comment {% else %} Comments {% endif %}</h3>
                         <div class="reviews-options d-flex flex-sm-row flex-column col p-0">
                             {% if user.is_authenticated %}
-                                <a href="{% url 'new_review' %}?subdept_id={{course.subdepartment.id}}&course_id={{course.id}}&instr_id={{instructor.id}}"" class="btn bg-tcf-orange text-white mb-3">
+                                <a href="{% url 'new_review' %}?subdept_id={{course.subdepartment.id}}&course_id={{course.id}}&instr_id={{instructor.id}}" class="btn bg-tcf-orange text-white mb-3">
                                     <i class="fa fa-plus" aria-hidden="true"></i> Add your review!
                                 </a>
                             {% else %}


### PR DESCRIPTION
Removed extra quote in tcf_website\templates\course\course_professor.html for review redirect.

(Originally missed when I approved and merged into dev, caught by Barrett).