### PR TITLE
more modest page sizes

### DIFF
--- a/tcf_website/api/paginations.py
+++ b/tcf_website/api/paginations.py
@@ -4,6 +4,6 @@ from rest_framework.pagination import PageNumberPagination
 
 class FlexiblePagination(PageNumberPagination):
     """Just a custom pagination class"""
-    # Page size is 20 by default - can specify this param in GET
     page_size = 20
+    max_page_size = 100
     page_size_query_param = 'page_size'

--- a/tcf_website/static/course/javascript/instr_data.js
+++ b/tcf_website/static/course/javascript/instr_data.js
@@ -6,7 +6,7 @@
 // Executed when DOM is ready
 jQuery(function($) {
     /* Fetch instructor data for given course */
-    var pageSize = "1000";
+    var pageSize = "100";
     var instrEndpoint = `/api/instructors/?course=${window.courseID}` +
         `&page_size=${pageSize}`;
     // var courseID is from global var in template

--- a/tcf_website/static/reviews/new_review.js
+++ b/tcf_website/static/reviews/new_review.js
@@ -64,7 +64,7 @@ jQuery(function($) {
 
         // Fetch course data from API, based on selected subdepartment
         var subdeptID = $("#subject").val();
-        var pageSize = "1000";
+        var pageSize = "100";
         var courseEndpoint = `/api/courses/?subdepartment=${subdeptID}
                               &page_size=${pageSize}&recent`;
         $.getJSON(courseEndpoint, function(data) {
@@ -99,7 +99,7 @@ jQuery(function($) {
 
         // Fetch instructor data from API, based on selected course
         var course = $("#course").val();
-        var pageSize = "1000";
+        var pageSize = "100";
         var instrEndpoint = `/api/instructors/?course=${course}` +
             `&page_size=${pageSize}`;
         $.getJSON(instrEndpoint, function(data) {


### PR DESCRIPTION
## GitHub Issues addressed

- @ajnye conversation about query optimizations 

## What I did

Adjusted API to not have an unlimited page size. Makes it so tCF can't get taken down by like four requests 

This comes after looking at the digital ocean where queries for related course information would take ~1 second on average and up to 30 seconds max. Shocking considering most queries could operate at <1ms. 