### PR TITLE
Add QA google form banner

### DIFF
--- a/tcf_website/templates/browse/browse.html
+++ b/tcf_website/templates/browse/browse.html
@@ -12,6 +12,7 @@
         {% include "../common/notification.html" %}
     </div> {% endcomment %}
     <div class="browse container">
+        {% include "../common/qa_form_banner.html" %}
         {% include "../common/leaderboard_ad.html" with ad_slot="9691204298" %}
 
         <!-- Browse page content -->

--- a/tcf_website/templates/common/qa_form_banner.html
+++ b/tcf_website/templates/common/qa_form_banner.html
@@ -1,0 +1,15 @@
+<div id="notification-panel" role="alert"
+     class="alert alert-info alert-dismissible text-left fade show">
+  <h4 class="alert-heading">We need your help!</h4>
+  <hr>
+  <p class="mb-0 text-inline">
+    Struggling with finding courses you actually want to take? Give us your feedback on improving theCourseForum’s Q&A feature here:
+    <a href="https://forms.gle/jMW2nZjUTzxypapX9" class="btn btn-sm btn-info ml-2">
+      Survey <i class="fa fa-arrow-right" aria-hidden="true"></i>
+    </a>
+  </p>
+
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>

--- a/tcf_website/templates/landing/landing.html
+++ b/tcf_website/templates/landing/landing.html
@@ -57,6 +57,7 @@
     <header class="masthead text-center">
         <div class="row">
             <div class="col-xl-8 mx-auto py-4">
+                {% include "../common/qa_form_banner.html" %}
                 <div class="about-logo row justify-content-center">
                     <img src="{% static 'base/img/new_logo.svg' %}" alt="theCourseForum logo" height="150px">
                     <div class="tagline text-left pt-3">


### PR DESCRIPTION
## GitHub Issues addressed

- NA

## What I did

- Added a banner to the landing and browse page that asks for feedback on tCF's questions & answers feature

## Screenshots

- Before
![image](https://github.com/thecourseforum/theCourseForum2/assets/80020297/32aa8c8a-800a-4d31-8d2e-39e000b4bc51)
![image](https://github.com/thecourseforum/theCourseForum2/assets/80020297/c2d38cae-f61e-4769-8c63-d6c388157fb4)

- After
![image](https://github.com/thecourseforum/theCourseForum2/assets/80020297/45b9b4ba-bdbc-4312-ab60-87cfc610aeaf)
![image](https://github.com/thecourseforum/theCourseForum2/assets/80020297/4551d4ae-42e4-4d1f-8983-25ed5fa838d9)


## Testing

- Checked for banner locally

## Questions/Discussions/Notes

- None