### PR TITLE
basic cache setup

### DIFF
--- a/tcf_core/settings/base.py
+++ b/tcf_core/settings/base.py
@@ -243,3 +243,11 @@ MESSAGE_TAGS = {
 
 # Required in Django 3.2+ (See https://stackoverflow.com/a/66971803)
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+# Caching
+# See: https://docs.djangoproject.com/en/4.2/topics/cache/#memcached
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+    }
+}

--- a/tcf_core/settings/prod.py
+++ b/tcf_core/settings/prod.py
@@ -17,3 +17,9 @@ if os.environ.get('DJANGO_SETTINGS_MODULE') == 'tcf_core.settings.prod':
 
     # Use secure connection for database access
     DATABASES['default']['OPTIONS'] = {'sslmode': 'require'}
+
+    # cached memcache
+    # see: https://docs.djangoproject.com/en/4.2/topics/cache/#memcached
+    CACHES['default'] = {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'
+    }

--- a/tcf_website/templates/browse/browse.html
+++ b/tcf_website/templates/browse/browse.html
@@ -1,5 +1,6 @@
 {% extends "base/base.html" %}
 {% load static %}
+{% load cache %}
 
 {% block title %}Browse - theCourseForum{% endblock %}
 
@@ -8,9 +9,7 @@
 {% endblock %}
 
 {% block content %}
-    {% comment %} <div class="container">
-        {% include "../common/notification.html" %}
-    </div> {% endcomment %}
+    {% cache 100000 courseDepartmentsList %}
     <div class="browse container">
         {% include "../common/qa_form_banner.html" %}
         {% include "../common/leaderboard_ad.html" with ad_slot="9691204298" %}
@@ -29,4 +28,5 @@
 
         </div>
     </div>
+    {% endcache %}
 {% endblock %}


### PR DESCRIPTION
## What I did

- Added a basic memcache and dummy cache to settings (https://docs.djangoproject.com/en/4.2/topics/cache/#memcached)
- Allows the use of @cache_page decorators, template fragment decorators, and fine-grained cache control

## Discussion

We have [Cachalot](https://django-cachalot.readthedocs.io/en/latest/) which caches at the request level. However, the ability to use fine-grained cache control could be very useful as we start rolling out more advanced features.

The ability to use cache provides a useful tool in the toolboxes of tCF developers. 