### PR TITLE
server 500 fix

### DIFF
--- a/tcf_core/settings/base.py
+++ b/tcf_core/settings/base.py
@@ -166,6 +166,7 @@ SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.social_auth.social_details',
     'social_core.pipeline.social_auth.social_uid',
     'tcf_core.auth_pipeline.auth_allowed',
+    'tcf_core.auth_pipeline.validate_email',
     'social_core.pipeline.social_auth.social_user',
     'social_core.pipeline.user.get_username',
     'social_core.pipeline.mail.mail_validation',


### PR DESCRIPTION
## GitHub Issues addressed
-Server 500 error upon getting outlook email. 

## What I did

- Changed Social Auth Pipeline to add email validation/send function since its essentially the same thing.

## Screenshots

- Before


- After
in base.py added     'tcf_core.auth_pipeline.validate_email': 

<img width="448" alt="Screenshot 2023-11-22 at 9 10 53 PM" src="https://github.com/thecourseforum/theCourseForum2/assets/134260297/a8475ade-78a6-4d8a-92a9-e007557990ae">


## Testing
Testing cant be done because it works locally so we probably need to deploy to see if anything fixes. 


## Questions/Discussions/Notes

-