### PR TITLE
fix(docker): proper caching + service init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ RUN apt-get update && \
 		unattended-upgrades \
 		nodejs && \
 	rm -rf /var/lib/apt/lists/*
-RUN npm install
+RUN curl -sSL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /wait-for-it.sh && chmod +x /wait-for-it.sh
+RUN npm install --no-fund --no-audit
 RUN pip3 install -r requirements.txt --disable-pip-version-check --no-cache-dir
-RUN python3 manage.py migrate && \
-    python3 manage.py collectstatic --noinput && \
-    python3 manage.py invalidate_cachalot tcf_website

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,12 @@ version: '3'
 services:
   web:
     build: .
-    command: bash -c "
-      python3 manage.py migrate &&
-      python3 manage.py collectstatic --noinput &&
-      python3 manage.py invalidate_cachalot tcf_website &&
-      echo Starting Django Server... &&
-      python3 manage.py runserver 0.0.0.0:8000"
+    command: bash -c "/wait-for-it.sh tcf_db:${DB_PORT} -- && \
+              python manage.py migrate && \
+              python manage.py collectstatic --noinput && \
+              python manage.py invalidate_cachalot tcf_website && \
+              echo 'Starting Django Server...' && \
+              python manage.py runserver 0.0.0.0:8000"
     volumes:
       - .:/app
       - /app/db/  # exclude the subfolder to prevent potential interference
@@ -16,6 +16,8 @@ services:
       - '8000:8000'
     container_name: tcf_django
     restart: always
+    depends_on:
+      - db
   db:
     image: postgres:15.4
     volumes:


### PR DESCRIPTION
should fix docker now

postgres wasn't fully initialized before migrations were run, causing errors.
used the "wait-for-it" script to ensure it runs first

prod doesn't use docker - no danger there