### PR TITLE
fix(docker): ignore node_modules to resolve windows builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
fix windows docker context builds