### PR TITLE
fix(docker): make wait-for-it compatible w/ prod db access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,20 @@
-version: '3'
+version: "3"
 
 services:
   web:
     build: .
-    command: bash -c "/wait-for-it.sh tcf_db:${DB_PORT} -- && \
-              python manage.py migrate && \
-              python manage.py collectstatic --noinput && \
-              python manage.py invalidate_cachalot tcf_website && \
-              echo 'Starting Django Server...' && \
-              python manage.py runserver 0.0.0.0:8000"
+    command:
+      bash -c "if [ \"${ENVIRONMENT}\" = 'dev' ]; then /wait-for-it.sh tcf_db:${DB_PORT} || exit 1; fi && \
+      python manage.py migrate && \
+      python manage.py collectstatic --noinput && \
+      python manage.py invalidate_cachalot tcf_website && \
+      echo 'Starting Django Server...' && \
+      python manage.py runserver 0.0.0.0:8000"
     volumes:
       - .:/app
-      - /app/db/  # exclude the subfolder to prevent potential interference
+      - /app/db/ # exclude the subfolder to prevent potential interference
     ports:
-      - '8000:8000'
+      - "8000:8000"
     container_name: tcf_django
     restart: always
     depends_on:


### PR DESCRIPTION
allow access to prod db using `.env.prod` details.

new "ENVIRONMENT" field located in all .env files (a default ENVIRONMENT has no impact, ignoring "wait-for-it".