### PR TITLE
fix(gae): unpin deployment action from main to v1

### DIFF
--- a/.github/workflows/master-to-app-engine.yml
+++ b/.github/workflows/master-to-app-engine.yml
@@ -64,7 +64,7 @@ jobs:
           python manage.py migrate
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
@@ -76,7 +76,7 @@ jobs:
         run: envsubst < .config/app.yaml.template > app.yaml
 
       - name: Deploy to Google App Engine
-        uses: google-github-actions/deploy-appengine@main
+        uses: google-github-actions/deploy-appengine@v1
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 


### PR DESCRIPTION
Take Google's advice in deployment to master:
<img width="870" alt="image" src="https://github.com/thecourseforum/theCourseForum2/assets/62671086/a038478e-85f2-4f6d-9734-d3223070805c">

![image](https://github.com/thecourseforum/theCourseForum2/assets/62671086/a5aec3ad-8616-4cc3-9117-89664e51f16c)
