### PR TITLE
Fix email verification

### DIFF
--- a/tcf_core/auth_pipeline.py
+++ b/tcf_core/auth_pipeline.py
@@ -4,6 +4,7 @@
 # pylint: disable=line-too-long
 """Custom authentication pipeline steps."""
 
+from functools import wraps
 from django.conf import settings
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
@@ -11,6 +12,7 @@ from django.core.mail import send_mail
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from social_core.pipeline.partial import partial
+from social_core.strategy import BaseStrategy
 
 from tcf_website.models import User
 
@@ -44,12 +46,33 @@ def password_validation(backend, details, request, response, *args, **kwargs):
             return redirect("/login/password_error", error=True)
     return {"password": response.get("password")}
 
+# Make BaseStrategy.validate_email() always return true, so that
+# social_core.pipeline.mail.mail_validation can be run multiple times
+def always_true(*args, **kwargs):
+    return True
+BaseStrategy.validate_email = always_true
 
-@partial
+# Wrapper over strategy.clean_partial_pipeline() to implement partial token persistence
+def partial_token_persistence(orig_func):
+    @wraps(orig_func)
+    def new_func(self, *args, **kwargs):
+        if (self.session.get('persist_partial_token', default=False)):
+            # Persist partial token
+            pass
+        else:
+            # Delete partial token
+            orig_func(self, *args, **kwargs)
+    return new_func
+BaseStrategy.clean_partial_pipeline = partial_token_persistence(BaseStrategy.clean_partial_pipeline)
+
 def collect_extra_info(
     strategy, backend, request, details, user=None, *args, **kwargs
 ):
     """Collect extra information on sign up."""
+
+    # Disable partial token persistence
+    strategy.session_set('persist_partial_token', False)
+
     if user:
         return {"is_new": False}
 
@@ -57,11 +80,18 @@ def collect_extra_info(
     # because it exists in FIELDS_STORED_IN_SESSION
     grad_year = strategy.session_get("grad_year", None)
     if not grad_year:
+        # If grad year isn't available yet, persist the current partial token
+        strategy.session_set('persist_partial_token', True)
+
         # if we return something besides a dict or None, then that is
         # returned to the user -- in this case we will redirect to a
         # view that can be used to get a password
-        return redirect(f"/login/collect_extra_info/{backend.name}")
-
+        return redirect(f"/login/collect_extra_info/{backend.name}"
+                        + "?verification_code="
+                        + request.GET['verification_code']
+                        + "&partial_token="
+                        + request.GET['partial_token']
+                        )
 
 USER_FIELDS = ["email", "username"]
 

--- a/tcf_core/auth_pipeline.py
+++ b/tcf_core/auth_pipeline.py
@@ -11,7 +11,6 @@ from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
 from django.shortcuts import redirect, render
 from django.urls import reverse
-from social_core.pipeline.partial import partial
 from social_core.strategy import BaseStrategy
 
 from tcf_website.models import User
@@ -46,17 +45,15 @@ def password_validation(backend, details, request, response, *args, **kwargs):
             return redirect("/login/password_error", error=True)
     return {"password": response.get("password")}
 
-# Make BaseStrategy.validate_email() always return true, so that
+# Make BaseStrategy.validate_email() always return True, so that
 # social_core.pipeline.mail.mail_validation can be run multiple times
-def always_true(*args, **kwargs):
-    return True
-BaseStrategy.validate_email = always_true
+BaseStrategy.validate_email = lambda *args, **kwargs: True
 
-# Wrapper over strategy.clean_partial_pipeline() to implement partial token persistence
 def partial_token_persistence(orig_func):
+    """Wrapper over strategy.clean_partial_pipeline() to implement partial token persistence."""
     @wraps(orig_func)
     def new_func(self, *args, **kwargs):
-        if (self.session.get('persist_partial_token', default=False)):
+        if self.session.get('persist_partial_token', default=False):
             # Persist partial token
             pass
         else:

--- a/tcf_website/views/auth.py
+++ b/tcf_website/views/auth.py
@@ -72,7 +72,12 @@ def collect_extra_info(request, method):
 
             # once we have the grad_year stashed in the session, we can
             # tell the pipeline to resume by using the "complete" endpoint
-            return redirect(reverse("social:complete", args=[method]))
+            return redirect(reverse("social:complete", args=[method])
+                            + "?verification_code="
+                            + request.GET['verification_code']
+                            + "&partial_token="
+                            + request.GET['partial_token']
+                            )
     else:
         form = ExtraUserInfoForm()
 


### PR DESCRIPTION
Problem: Whenever someone tried to create an account by email and password (not sign in with Google), clicking on the email verification link would cause a Server 500 Error, and the account would not be created.

The cause of the problem: Between the time the user registers a new account and the time the user clicks on the email verification link, the user's data is stored in the database table `social_auth_partial`. For an unknown reason, the production server behaves as if the verification link was visited BEFORE the user clicks the link. This removes the user's data from the database, such that their account can't be created when they click the link.

Solution: Make the user's data persist in the database until the user manually enters their graduation year, then delete the entry from `social_auth_partial`.

## GitHub Issues addressed

- This PR closes https://github.com/thecourseforum/theCourseForum2/issues/802

## Testing

- Successfully created an account locally with email login, and verified that none of the new partial tokens remain on the database after account creation.
- Successfully created an account on the Heroku dev server with email login.
- To test:
    - If you already have an account, delete your account before recreating it by My Profile > Delete Profile.
    - To check that the user's data is properly removed from the database after account creation, `psql` into the database and run the query `SELECT * FROM social_auth_partial;`