### PR TITLE
feat(courses): grey out courses not being taught

### DIFF
--- a/tcf_website/templates/search/search.html
+++ b/tcf_website/templates/search/search.html
@@ -61,9 +61,7 @@
                   <div class="col-12">
                     <h5><a href="{% url 'department' dept_id=dept_data.dept_id %}">{{ dept }} / {{ dept_data.subdept_name }}</a></h5>
                       {% for c in dept_data.courses %}
-                        {% if c != dept_data.courses.0 %}
-                        {% endif %}
-                        <div class="list-group-item list-group-item-light text-dark p-2">
+                      <div class="list-group-item {% if c.recent %}list-group-item-light{% else %}list-group-item-secondary{% endif %} text-dark p-2">
                           <div class="row">
                             <div class="col-md-11 align-self-center">
                                 <a href="{% url 'course' mnemonic=c.mnemonic.split.0 course_number=c.number %}">

--- a/tcf_website/views/browse.py
+++ b/tcf_website/views/browse.py
@@ -171,10 +171,6 @@ def course_view(request, mnemonic, course_number):
         if i.section_nums.count(None) > 0:
             i.section_nums.remove(None)
 
-    taught_this_semester = Section.objects.filter(
-        course=course, semester=latest_semester
-    ).exists()
-
     # Note: Wanted to use .annotate() but couldn't figure out a way
     # So created a dictionary on the fly to minimize database access
     semesters = {s.id: s for s in Semester.objects.all()}
@@ -205,7 +201,7 @@ def course_view(request, mnemonic, course_number):
             "instructors": instructors,
             "latest_semester": latest_semester,
             "breadcrumbs": breadcrumbs,
-            "taught_this_semester": taught_this_semester,
+            "taught_this_semester": course.is_recent(),
         },
     )
 


### PR DESCRIPTION
note untaught classes

<img width="1271" alt="image" src="https://github.com/thecourseforum/theCourseForum2/assets/62671086/8bcaf71f-28a9-43bb-aacf-c50147ab32e9">


# TODO

- talk to design team
- where else should courses be greyed out besides `/search`? (What other endpoints display courses that could potentially not be taught in the current semester?)