### PR TITLE
Add extra error logs

### DIFF
--- a/tcf_core/settings/handle_exceptions_middleware.py
+++ b/tcf_core/settings/handle_exceptions_middleware.py
@@ -4,6 +4,25 @@ import sys
 import traceback
 
 
+# Source: https://gist.github.com/defrex/6140951
+def pretty_request(request):
+    """Prints request details and headers."""
+    headers = ''
+    for header, value in request.META.items():
+        if not header.startswith('HTTP'):
+            continue
+        header = '-'.join([h.capitalize() for h in header[5:].lower().split('_')])
+        headers += f'{header}: {value}\n'
+
+    return (
+        f'{request.method} HTTP/1.1\n'
+        f'Content-Length: {request.META["CONTENT_LENGTH"]}\n'
+        f'Content-Type: {request.META["CONTENT_TYPE"]}\n'
+        f'{headers}\n\n'
+        f'{request.body}'
+    )
+
+
 class HandleExceptionsMiddleware:
     """Records information about errors at any point."""
 
@@ -15,9 +34,13 @@ class HandleExceptionsMiddleware:
 
         return response
 
-    def process_exception(self, request, exception):
+    def process_exception(self, request, exception): # pylint: disable=unused-argument
         """Gets and prints out all errors to terminal for tracking"""
-        print("Error on Load")
-        print("Internal Server Error: " + request.get_full_path(), file=sys.stderr)
+        print("========= Internal server error =========", file=sys.stderr)
+        print("========== Request path ==========", file=sys.stderr)
+        print(request.get_full_path(), file=sys.stderr)
+        print("========== Request details ==========", file=sys.stderr)
+        print("Request: " + pretty_request(request), file=sys.stderr)
+        print("========== Exception ==========", file=sys.stderr)
         print(traceback.format_exc(), file=sys.stderr)
-        print(exception)
+        print("========================================", file=sys.stderr)


### PR DESCRIPTION
## GitHub Issues addressed

- Adding logs to help debug server 500 error

## What I did

- Reformatted and added request headers to error logs

## Screenshots

- Before
> tcf_django  | Error on Load
tcf_django  | Internal Server Error: /department/19/Fall+2024/
tcf_django  | Department matching query does not exist.
tcf_django  | Traceback (most recent call last):
tcf_django  |   File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
tcf_django  |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
tcf_django  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tcf_django  |   File "/app/tcf_website/views/browse.py", line 57, in department
tcf_django  |     dept = Department.objects.prefetch_related("subdepartment_set").get(pk=dept_id)
tcf_django  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tcf_django  |   File "/usr/local/lib/python3.11/site-packages/django/db/models/query.py", line 637, in get
tcf_django  |     raise self.model.DoesNotExist(
tcf_django  | tcf_website.models.models.Department.DoesNotExist: Department matching query does not exist.

- After
> tcf_django  | ========= Internal server error =========
tcf_django  | ========== Request path ==========
tcf_django  | /department/19/Fall+2024/
tcf_django  | ========== Request details ==========
tcf_django  | Request: GET HTTP/1.1
tcf_django  | Content-Length: 
tcf_django  | Content-Type: text/plain
tcf_django  | Host: localhost:8000
tcf_django  | Connection: keep-alive
tcf_django  | Cache-Control: max-age=0
tcf_django  | Sec-Ch-Ua: "Microsoft Edge";v="129", "Not=A?Brand";v="8", "Chromium";v="129"
tcf_django  | Sec-Ch-Ua-Mobile: ?0
tcf_django  | Sec-Ch-Ua-Platform: "macOS"
tcf_django  | Dnt: 1
tcf_django  | Upgrade-Insecure-Requests: 1
tcf_django  | User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36 Edg/129.0.0.0
tcf_django  | Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
tcf_django  | Sec-Fetch-Site: none
tcf_django  | Sec-Fetch-Mode: navigate
tcf_django  | Sec-Fetch-User: ?1
tcf_django  | Sec-Fetch-Dest: document
tcf_django  | Accept-Encoding: gzip, deflate, br, zstd
tcf_django  | Accept-Language: en-US,en;q=0.9
tcf_django  | Cookie: [redacted]
tcf_django  | 
tcf_django  | 
tcf_django  | b''
tcf_django  | ========== Exception ==========
tcf_django  | Traceback (most recent call last):
tcf_django  |   File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
tcf_django  |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
tcf_django  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tcf_django  |   File "/app/tcf_website/views/browse.py", line 57, in department
tcf_django  |     dept = Department.objects.prefetch_related("subdepartment_set").get(pk=dept_id)
tcf_django  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tcf_django  |   File "/usr/local/lib/python3.11/site-packages/django/db/models/query.py", line 637, in get
tcf_django  |     raise self.model.DoesNotExist(
tcf_django  | tcf_website.models.models.Department.DoesNotExist: Department matching query does not exist.
tcf_django  | 
tcf_django  | ========================================

## Testing

- Run locally and navigate to `http://localhost:8000/department/19/Fall+2024/`, then check console output

## Questions/Discussions/Notes

-
