### PR TITLE
deprecation warning to FlexiblePagination in paginations.py

### DIFF
--- a/scripts/reset-db.sh
+++ b/scripts/reset-db.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-DB_FILE="${DB_FILE:-db/latest.sql}"
+DB_FILE="${1:-db/latest.sql}"
 
 if [ ! -f "$DB_FILE" ]; then 
   echo "Database file '$DB_FILE' not found."

--- a/tcf_website/api/paginations.py
+++ b/tcf_website/api/paginations.py
@@ -1,5 +1,8 @@
 """"Custom DRF pagination classes"""
 
+import warnings
+
+from django.core.paginator import Paginator  # to be used instead of FlexiblePagination
 from rest_framework.pagination import PageNumberPagination
 
 
@@ -9,3 +12,11 @@ class FlexiblePagination(PageNumberPagination):
     # Page size is 20 by default - can specify this param in GET
     page_size = 20
     page_size_query_param = "page_size"
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "The FlexiblePagination class is deprecated. Please use Paginator from django.core.paginator instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
## GitHub Issues addressed

- This PR closes

## What I did

- Deprecated FlexiblePagination in preparation of using Paginator from django.core.paginator

## Screenshots

- Before
- After

## Testing

- A brief explanation of tests done/written or how reviewers can test your work

## Questions/Discussions/Notes

-
