### PR TITLE
Default sorting option for course - instructor reviews

### DIFF
--- a/tcf_website/models/models.py
+++ b/tcf_website/models/models.py
@@ -966,8 +966,10 @@ class Review(models.Model):
                         output_field=fields.FloatField(),
                     )
                 ).order_by("average")
-            case "Most Recent" | _:
+            case "Most Recent":
                 return reviews.order_by("-created")
+            case "Default" | _:
+                return reviews
 
     @staticmethod
     def paginate(reviews: "QuerySet[Review]", page_number, reviews_per_page=10) -> "Page[Review]":

--- a/tcf_website/views/browse.py
+++ b/tcf_website/views/browse.py
@@ -182,7 +182,7 @@ def course_view(
     )
 
 
-def course_instructor(request, course_id, instructor_id, method="Most Recent"):
+def course_instructor(request, course_id, instructor_id, method="Default"):
     """View for course instructor page."""
     section_last_taught = (
         Section.objects.filter(course=course_id, instructors=instructor_id)


### PR DESCRIPTION
## Completed:
- Created "Default" sorting method for reviews so that only the first ten reviews are fetched when a course instructor is loaded.
- This mode is not selectable and fetches the earliest reviews.
