### PR TITLE
fix: seperated marketing and design teams on the about page

### DIFF
--- a/tcf_website/templates/about/current_team.html
+++ b/tcf_website/templates/about/current_team.html
@@ -55,9 +55,32 @@
       </div>
     </div>
 
+    <div class="design-team jumbotron py-5 bg-light">
+      <div class="container">
+        <h3>Design Team</h3>
+        <hr/>
+        <div class="row text-left">
+          {% for member in design_team %}
+            <div class="col-lg-3 col-sm-6 d-flex">
+              <div class="member card mb-4 shadow-sm flex-fill">
+                <div class="pfp">
+                  <img class="card-img-top" src="{% static 'about/team-pfps/'|add:member.img_filename %}" alt="{{ member.name }}">
+                </div>
+                <div class="card-body">
+                  <h5 class="card-text">{{ member.name }}</h5>
+                  <p class="card-text small text-muted">Class of {{ member.class }}</p>
+                </div>
+              </div>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+
+
     <div class="marketing-team jumbotron py-5 bg-light">
       <div class="container">
-        <h3>Marketing & Design Team</h3>
+        <h3>Marketing Team</h3>
         <hr/>
         <div class="row text-left">
           {% for member in marketing_team %}

--- a/tcf_website/views/index.py
+++ b/tcf_website/views/index.py
@@ -60,6 +60,7 @@ class AboutView(TemplateView):
         context["executive_team"] = self.team_info["executive_team"]
         context["engineering_team"] = self.team_info["engineering_team"]
         context["marketing_team"] = self.team_info["marketing_team"]
+        context["design_team"] = self.team_info["design_team"]
         context["founders"] = self.alum_info["founders"]
         context["contributors"] = self.alum_info["contributors"]
         return context

--- a/tcf_website/views/team_info.json
+++ b/tcf_website/views/team_info.json
@@ -264,7 +264,7 @@
       "github": "namaikureishi"
     }
   ],
-  "marketing_team": [
+  "design_team": [
     {
       "name": "Chai Zhang",
       "role": "Designer",
@@ -276,7 +276,9 @@
       "role": "Designer",
       "class": "2028",
       "img_filename": "DM_Tara_Vidyababu.webp"
-    },
+    }
+  ],
+  "marketing_team": [
     {
       "name": "Carissa Chen",
       "role": "Marketing",
@@ -288,6 +290,12 @@
       "role": "Marketing",
       "class": "2027",
       "img_filename": "DM_Julie_Huang.jpg"
+    },
+    {
+      "name": "Alyssa Zhang",
+      "role": "Marketing",
+      "class": "2027",
+      "img_filename": "DM_Alyssa_Zhang.jpg"
     }
   ]
 }


### PR DESCRIPTION
## GitHub Issues addressed

- This PR closes

## What I did
I separated the marketing and design team on the about page

-

## Screenshots

- Before
- 
<img width="1055" alt="image" src="https://github.com/user-attachments/assets/0b725bac-a3fc-48fc-a2b7-8fb7b7caea34" />

- After
<img width="817" alt="Screenshot 2025-02-24 at 3 10 40 PM" src="https://github.com/user-attachments/assets/d06b2ca9-84ac-4763-8c55-ed3189850799" />


## Testing

- A brief explanation of tests done/written or how reviewers can test your work

In order to test, I opened up the about page and then ensured that the people who are on the marketing and design team are not in the same group and rather are split up.

## Questions/Discussions/Notes

-
