### PR TITLE
Django session

### DIFF
--- a/tcf_core/context_processors.py
+++ b/tcf_core/context_processors.py
@@ -1,7 +1,5 @@
 """Inject extra context to TCF templates."""
 
-import ast
-
 from django.conf import settings
 
 from tcf_website.models import Discipline, Semester, Subdepartment
@@ -13,33 +11,6 @@ def base(request):
         "DEBUG": settings.DEBUG,
         "USER": request.user,
         "LATEST_SEMESTER": Semester.latest(),
-    }
-
-
-def history_cookies(request):
-    """Puts history from cookies into context variables."""
-    if "previous_paths" in request.COOKIES:
-        previous_paths = request.COOKIES["previous_paths"]
-        previous_paths = ast.literal_eval(previous_paths)
-    else:
-        previous_paths = ""
-
-    if "previous_paths_titles" in request.COOKIES:
-        previous_paths_titles = request.COOKIES["previous_paths_titles"]
-        previous_paths_titles = ast.literal_eval(previous_paths_titles)
-    else:
-        previous_paths_titles = ""
-
-    previous_paths_titles = [title[:80] for title in previous_paths_titles]
-
-    previous_paths_and_titles = None
-    if len(previous_paths) > 0 and len(previous_paths_titles) > 0:
-        previous_paths_and_titles = zip(previous_paths, previous_paths_titles)
-
-    return {
-        "previous_paths": previous_paths,
-        "previous_path_titles": previous_paths_titles,
-        "previous_paths_and_titles": previous_paths_and_titles,
     }
 
 

--- a/tcf_core/context_processors.py
+++ b/tcf_core/context_processors.py
@@ -30,7 +30,7 @@ def history_cookies(request):
     else:
         previous_paths_titles = ""
 
-    previous_paths_titles = [title[:80] + "..." for title in previous_paths_titles]
+    previous_paths_titles = [title[:80] for title in previous_paths_titles]
 
     previous_paths_and_titles = None
     if len(previous_paths) > 0 and len(previous_paths_titles) > 0:
@@ -50,19 +50,18 @@ def searchbar_context(request):
         number__gte=latest_semester.number - 50  # 50 = 5 years * 10 semesters
     ).order_by("-number")
 
-    # Get saved filters from the session (or use defaults)
-    saved_filters = request.session.get("search_filters", {})
-
+    # No longer use session to store filters
+    # Empty defaults are provided instead
     context = {
         "disciplines": Discipline.objects.all().order_by("name"),
         "subdepartments": Subdepartment.objects.all().order_by("mnemonic"),
         "semesters": recent_semesters,
-        "selected_disciplines": saved_filters.get("disciplines", []),
-        "selected_subdepartments": saved_filters.get("subdepartments", []),
-        "selected_weekdays": saved_filters.get("weekdays", []),
-        "from_time": saved_filters.get("from_time", ""),
-        "to_time": saved_filters.get("to_time", ""),
-        "open_sections": saved_filters.get("open_sections", False),
-        "min_gpa": saved_filters.get("min_gpa", 0.0),
+        "selected_disciplines": [],
+        "selected_subdepartments": [],
+        "selected_weekdays": [],
+        "from_time": "",
+        "to_time": "",
+        "open_sections": False,
+        "min_gpa": 0.0,
     }
     return context

--- a/tcf_core/settings/base.py
+++ b/tcf_core/settings/base.py
@@ -131,7 +131,6 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "tcf_core.context_processors.base",
-                "tcf_core.context_processors.history_cookies",
                 "tcf_core.context_processors.searchbar_context",
             ],
         },

--- a/tcf_core/settings/record_middleware.py
+++ b/tcf_core/settings/record_middleware.py
@@ -22,29 +22,14 @@ class RecordMiddleware:  # pylint: disable=too-few-public-methods
             previous_paths = []
             previous_paths_titles = []
 
+        # Process the request and get response
         response = self.get_response(request)
-        if (
-            check_path(request.path)
-            and request.session.get("instructor_fullname") is not None
-        ):
-            previous_paths.insert(0, request.build_absolute_uri())
-            previous_paths = list(dict.fromkeys(previous_paths))
 
-            title = request.session.get("course_code")
-            if request.session.get("instructor_fullname") is not None:
-                title += " - " + request.session.get("instructor_fullname")
-            title += " - " + request.session.get("course_title")
+        # We no longer manage history through the middleware
+        # This is now handled by client-side JavaScript using localStorage
+        # The cookie is still retained for backwards compatibility
+        # but it's populated by JavaScript, not by the middleware
 
-            previous_paths_titles.insert(0, title)
-            previous_paths_titles = list(dict.fromkeys(previous_paths_titles))
-
-            # Keeps top 10 items in list
-            if len(previous_paths) > 10:
-                previous_paths = previous_paths[:10]
-                previous_paths_titles = previous_paths_titles[:10]
-
-            response.set_cookie("previous_paths", previous_paths)
-            response.set_cookie("previous_paths_titles", previous_paths_titles)
         return response
 
 

--- a/tcf_core/settings/record_middleware.py
+++ b/tcf_core/settings/record_middleware.py
@@ -1,34 +1,22 @@
 """Middleware for recording cookie information."""
 
-import ast
-
 
 class RecordMiddleware:  # pylint: disable=too-few-public-methods
-    """Records information about course section info into cookies."""
+    """
+    Previously recorded course section info into cookies.
+    Now does nothing as this functionality has been moved to client-side
+    localStorage to avoid polluting Django sessions.
+    """
 
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
-        if "previous_paths_titles" in request.COOKIES:
-            previous_paths = request.COOKIES["previous_paths"]
-            # Converts string representation of list into list object
-            previous_paths = ast.literal_eval(previous_paths)
-
-            previous_paths_titles = request.COOKIES["previous_paths_titles"]
-            # Converts string representation of list into list object
-            previous_paths_titles = ast.literal_eval(previous_paths_titles)
-        else:
-            previous_paths = []
-            previous_paths_titles = []
-
         # Process the request and get response
         response = self.get_response(request)
 
-        # We no longer manage history through the middleware
-        # This is now handled by client-side JavaScript using localStorage
-        # The cookie is still retained for backwards compatibility
-        # but it's populated by JavaScript, not by the middleware
+        # We no longer set cookies for history tracking
+        # All history is now managed via localStorage in the browser
 
         return response
 

--- a/tcf_website/static/common/recently_viewed.js
+++ b/tcf_website/static/common/recently_viewed.js
@@ -55,11 +55,17 @@ function saveCourseInfoIfPresent() {
   }
 
   // Insert at beginning and remove duplicates
-  previousPaths.unshift(currentUrl);
-  previousPaths = [...new Set(previousPaths)];
+  // First check if the title already exists in the array
+  const existingIndex = previousPathsTitles.indexOf(title);
+  if (existingIndex !== -1) {
+    // If the title exists, remove both the title and its corresponding path
+    previousPathsTitles.splice(existingIndex, 1);
+    previousPaths.splice(existingIndex, 1);
+  }
 
+  // Add the new path and title at the beginning
+  previousPaths.unshift(currentUrl);
   previousPathsTitles.unshift(title);
-  previousPathsTitles = [...new Set(previousPathsTitles)];
 
   // Keep only the top 10 items
   if (previousPaths.length > 10) {

--- a/tcf_website/static/common/recently_viewed.js
+++ b/tcf_website/static/common/recently_viewed.js
@@ -79,21 +79,4 @@ function saveCourseInfoIfPresent() {
     "previous_paths_titles",
     JSON.stringify(previousPathsTitles),
   );
-
-  // Also set cookies for compatibility with existing server-side code
-  setCookie("previous_paths", JSON.stringify(previousPaths), 30);
-  setCookie("previous_paths_titles", JSON.stringify(previousPathsTitles), 30);
-}
-
-/**
- * Helper function to set cookies
- */
-function setCookie(name, value, days) {
-  let expires = "";
-  if (days) {
-    const date = new Date();
-    date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
-    expires = "; expires=" + date.toUTCString();
-  }
-  document.cookie = name + "=" + (value || "") + expires + "; path=/";
 }

--- a/tcf_website/static/common/recently_viewed.js
+++ b/tcf_website/static/common/recently_viewed.js
@@ -1,0 +1,93 @@
+/**
+ * This file handles the recently viewed courses/instructors using localStorage
+ * It replaces the server-side session storage with client-side storage
+ */
+
+document.addEventListener("DOMContentLoaded", function () {
+  // Check if we're on a course page by looking for course code and title in the page
+  saveCourseInfoIfPresent();
+});
+
+/**
+ * Saves course information to localStorage if we're on a course or course-instructor page
+ */
+function saveCourseInfoIfPresent() {
+  // Find course information in the page
+  // This is adapting the session-based logic from browse.py and course_instructor views
+  const courseCode = document.querySelector(
+    'meta[name="course-code"]',
+  )?.content;
+  const courseTitle = document.querySelector(
+    'meta[name="course-title"]',
+  )?.content;
+
+  if (!courseTitle) {
+    return; // Not on a course or club page, or missing required data
+  }
+
+  // Get current URL
+  const currentUrl = window.location.href;
+
+  // Create the title in the same format as the server-side code
+
+  let title = "";
+
+  if (courseCode) {
+    title += courseCode + " | ";
+  }
+
+  title += courseTitle;
+
+  // Get existing history from localStorage
+  let previousPaths = [];
+  let previousPathsTitles = [];
+
+  try {
+    const savedPaths = localStorage.getItem("previous_paths");
+    const savedTitles = localStorage.getItem("previous_paths_titles");
+
+    if (savedPaths && savedTitles) {
+      previousPaths = JSON.parse(savedPaths);
+      previousPathsTitles = JSON.parse(savedTitles);
+    }
+  } catch (e) {
+    console.error("Error loading history from localStorage:", e);
+  }
+
+  // Insert at beginning and remove duplicates
+  previousPaths.unshift(currentUrl);
+  previousPaths = [...new Set(previousPaths)];
+
+  previousPathsTitles.unshift(title);
+  previousPathsTitles = [...new Set(previousPathsTitles)];
+
+  // Keep only the top 10 items
+  if (previousPaths.length > 10) {
+    previousPaths = previousPaths.slice(0, 10);
+    previousPathsTitles = previousPathsTitles.slice(0, 10);
+  }
+
+  // Save back to localStorage
+  localStorage.setItem("previous_paths", JSON.stringify(previousPaths));
+  localStorage.setItem(
+    "previous_paths_titles",
+    JSON.stringify(previousPathsTitles),
+  );
+
+  // Also set cookies for compatibility with existing server-side code
+  setCookie("previous_paths", JSON.stringify(previousPaths), 30);
+  setCookie("previous_paths_titles", JSON.stringify(previousPathsTitles), 30);
+}
+
+/**
+ * Helper function to set cookies
+ */
+function setCookie(name, value, days) {
+  let expires = "";
+  if (days) {
+    const date = new Date();
+    date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
+    expires = "; expires=" + date.toUTCString();
+  }
+  document.cookie = name + "=" + (value || "") + expires + "; path=/";
+}

--- a/tcf_website/static/search/filters.js
+++ b/tcf_website/static/search/filters.js
@@ -267,7 +267,11 @@ document.addEventListener("DOMContentLoaded", function () {
   const resetButton = document.querySelector('button[type="reset"]');
   resetButton.addEventListener("click", function (e) {
     e.preventDefault(); // Prevent default reset behavior
+    clearFilters();
+  });
 
+  // Function to clear all filters
+  function clearFilters() {
     // Reset checkboxes
     document.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
       checkbox.checked = false;
@@ -305,7 +309,7 @@ document.addEventListener("DOMContentLoaded", function () {
     // Reorder lists after clearing filters
     reorderList(".subject-list", ".form-check-subjects");
     reorderList(".discipline-list", ".form-check-disciplines");
-  });
+  }
 
   // Add weekdays handling
   function updateWeekdays() {

--- a/tcf_website/static/search/filters.js
+++ b/tcf_website/static/search/filters.js
@@ -12,16 +12,25 @@ document.addEventListener("DOMContentLoaded", function () {
   const minGpaText = document.getElementById("min-gpa-text");
   const minGpaInput = document.getElementById("min-gpa-input");
 
+  // Check if filters should be loaded from localStorage
+  loadFiltersFromLocalStorage();
+
   // Check initial state (in case of page refresh with active filters)
   updateButtonState();
 
   // Add event listeners to all filter inputs
   [...filterInputs, ...dayFilters, openSections].forEach((input) => {
-    input.addEventListener("change", updateButtonState);
+    input.addEventListener("change", function () {
+      updateButtonState();
+      saveFiltersToLocalStorage();
+    });
   });
 
   [timeFrom, timeTo].forEach((input) => {
-    input.addEventListener("input", updateButtonState);
+    input.addEventListener("input", function () {
+      updateButtonState();
+      saveFiltersToLocalStorage();
+    });
   });
 
   // Min GPA slider and text input synchronization
@@ -30,6 +39,7 @@ document.addEventListener("DOMContentLoaded", function () {
     minGpaText.value = value;
     minGpaInput.value = value;
     updateButtonState();
+    saveFiltersToLocalStorage();
   });
 
   minGpaText.addEventListener("change", function () {
@@ -51,6 +61,7 @@ document.addEventListener("DOMContentLoaded", function () {
     minGpaSlider.value = value;
     minGpaInput.value = value;
     updateButtonState();
+    saveFiltersToLocalStorage();
   });
 
   // Allow enter key on min-gpa-text to apply the filter
@@ -61,6 +72,101 @@ document.addEventListener("DOMContentLoaded", function () {
       document.querySelector('button[type="submit"]').click(); // Submit the form
     }
   });
+
+  // Save current filter state to localStorage
+  function saveFiltersToLocalStorage() {
+    // Get selected subdepartments
+    const selectedSubdepts = Array.from(
+      document.querySelectorAll(".form-check-subjects:checked"),
+    ).map((input) => input.value);
+
+    // Get selected disciplines
+    const selectedDisciplines = Array.from(
+      document.querySelectorAll(".form-check-disciplines:checked"),
+    ).map((input) => input.value);
+
+    // Get selected weekdays
+    const selectedWeekdays = Array.from(
+      document.querySelectorAll(".day-checkbox:checked"),
+    ).map((input) => input.value);
+
+    // Create filters object
+    const filters = {
+      subdepartments: selectedSubdepts,
+      disciplines: selectedDisciplines,
+      weekdays: selectedWeekdays,
+      from_time: timeFrom ? timeFrom.value : "",
+      to_time: timeTo ? timeTo.value : "",
+      open_sections: openSections ? openSections.checked : false,
+      min_gpa: minGpaInput ? parseFloat(minGpaInput.value || "0.0") : 0.0,
+    };
+
+    // Save to localStorage
+    localStorage.setItem("search_filters", JSON.stringify(filters));
+  }
+
+  // Load filters from localStorage
+  function loadFiltersFromLocalStorage() {
+    const savedFilters = localStorage.getItem("search_filters");
+    if (!savedFilters) return;
+
+    try {
+      const filters = JSON.parse(savedFilters);
+
+      // Set subdepartments
+      if (filters.subdepartments && filters.subdepartments.length) {
+        filters.subdepartments.forEach((mnemonic) => {
+          const input = document.getElementById(`subject-${mnemonic}`);
+          if (input) input.checked = true;
+        });
+      }
+
+      // Set disciplines
+      if (filters.disciplines && filters.disciplines.length) {
+        filters.disciplines.forEach((name) => {
+          const input = document.getElementById(
+            `discipline-${name.toLowerCase().replace(/\s+/g, "-")}`,
+          );
+          if (input) input.checked = true;
+        });
+      }
+
+      // Set weekdays
+      if (filters.weekdays && filters.weekdays.length) {
+        filters.weekdays.forEach((day) => {
+          const dayMap = {
+            MON: "monday",
+            TUE: "tuesday",
+            WED: "wednesday",
+            THU: "thursday",
+            FRI: "friday",
+          };
+          const input = document.getElementById(dayMap[day]);
+          if (input) input.checked = true;
+        });
+        updateWeekdays(); // Update the hidden input
+      }
+
+      // Set time values
+      if (timeFrom && filters.from_time) timeFrom.value = filters.from_time;
+      if (timeTo && filters.to_time) timeTo.value = filters.to_time;
+
+      // Set open sections
+      if (openSections && filters.open_sections !== undefined) {
+        openSections.checked = filters.open_sections;
+      }
+
+      // Set min GPA
+      if (filters.min_gpa !== undefined) {
+        const gpaValue = parseFloat(filters.min_gpa).toFixed(1);
+        if (minGpaSlider) minGpaSlider.value = gpaValue;
+        if (minGpaText) minGpaText.value = gpaValue;
+        if (minGpaInput) minGpaInput.value = gpaValue;
+      }
+    } catch (e) {
+      console.error("Error loading filters from localStorage:", e);
+    }
+  }
 
   // Checks for active filters or inactive day filters to determine button state
   function updateButtonState() {
@@ -193,6 +299,9 @@ document.addEventListener("DOMContentLoaded", function () {
     updateWeekdays();
     updateButtonState();
 
+    // Clear localStorage filters
+    localStorage.removeItem("search_filters");
+
     // Reorder lists after clearing filters
     reorderList(".subject-list", ".form-check-subjects");
     reorderList(".discipline-list", ".form-check-disciplines");
@@ -219,6 +328,7 @@ document.addEventListener("DOMContentLoaded", function () {
       checkbox.dispatchEvent(new Event("change"));
       updateWeekdays();
       updateButtonState();
+      saveFiltersToLocalStorage();
     });
   });
 
@@ -227,6 +337,7 @@ document.addEventListener("DOMContentLoaded", function () {
     checkbox.addEventListener("change", () => {
       updateWeekdays();
       updateButtonState();
+      saveFiltersToLocalStorage();
     });
   });
 
@@ -236,25 +347,7 @@ document.addEventListener("DOMContentLoaded", function () {
   // Clear filters when window is resized to mobile view
   window.addEventListener("resize", function () {
     if (window.innerWidth <= 992) {
-      // Reset all checkboxes
-      document
-        .querySelectorAll('input[type="checkbox"]')
-        .forEach((checkbox) => {
-          checkbox.checked = false;
-        });
-
-      // Clear time inputs
-      timeFrom.value = "";
-      timeTo.value = "";
-
-      // Reset min GPA
-      if (minGpaSlider) minGpaSlider.value = 0.0;
-      if (minGpaText) minGpaText.value = 0.0;
-      if (minGpaInput) minGpaInput.value = 0.0;
-
-      // Update hidden inputs and button state
-      updateWeekdays();
-      updateButtonState();
+      clearFilters();
     }
   });
 });

--- a/tcf_website/templates/base/index.html
+++ b/tcf_website/templates/base/index.html
@@ -19,6 +19,9 @@
     <meta property="og:site_name" content="theCourseForum">
     <meta property="og:locale" content="en_US">
 
+    <!-- Course/Instructor metadata for localStorage -->
+    {% block page_metadata %}{% endblock %}
+
     <!-- Twitter Card Data -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="theCourseForum - Your Guide to Courses at UVA">
@@ -80,6 +83,9 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
           integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
           crossorigin="anonymous"></script>
+  
+  <!-- Recently viewed courses JavaScript -->
+  <script src="{% static 'common/recently_viewed.js' %}"></script>
 
   {% block basejs %}{% endblock %}
 

--- a/tcf_website/templates/club/club.html
+++ b/tcf_website/templates/club/club.html
@@ -1,7 +1,12 @@
 {% extends "base/base.html" %}
 {% load static %}
 
-{% block title %}{{ club.name }} - theCourseForum{% endblock %}
+{% block title %}{{ club.name }} | theCourseForum{% endblock %}
+
+{% block page_metadata %}
+<!-- Club meta data for localStorage (using same structure as courses) -->
+{% if course_title %}<meta name="course-title" content="{{ course_title }}">{% endif %}
+{% endblock %}
 
 {% block styles %}
 <link rel="stylesheet" href="{% static 'course/course_professor.css' %}" />

--- a/tcf_website/templates/common/history_page_modal.html
+++ b/tcf_website/templates/common/history_page_modal.html
@@ -2,23 +2,24 @@
 {% load static %}
 <div class="modal fade" id={{ path_id }} tabindex="-1" role="dialog" aria-labelledby="deleteModalLabel"
      aria-hidden="true">
-    <div class="modal-dialog modal-lg" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Recently Viewed</h5>
+    <div class="modal-dialog modal-lg shadow-sm" role="document">
+        <div class="modal-content border-0">
+            <div class="modal-header border-bottom-0">
+                <h5 class="modal-title font-weight-bold">Recently Viewed</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <div class="modal-body">
+            <div class="modal-body py-0 px-4">
                 <div class="text-center">
                     {% if previous_paths_and_titles is None %}
-                        <p>No course sections viewed yet.</p>
+                        <p class="text-muted my-4">No course sections viewed yet.</p>
                     {% endif %}
+                    <div class="list-group list-group-flush mb-3">
                     {% for path, title in previous_paths_and_titles %}
-                        <a class="card-text mb-3" href={{path}}>{{title}}</a>
-                        <br>
+                        <a class="list-group-item list-group-item-action border-left-0 border-right-0 rounded-0" href={{path}}>{{title}}</a>
                     {% endfor %}
+                    </div>
                 </div>
             </div>
         </div>

--- a/tcf_website/templates/common/history_page_modal.html
+++ b/tcf_website/templates/common/history_page_modal.html
@@ -12,16 +12,62 @@
             </div>
             <div class="modal-body py-0 px-4">
                 <div class="text-center">
-                    {% if previous_paths_and_titles is None %}
+                    <div id="history-items-container">
                         <p class="text-muted my-4">No course sections viewed yet.</p>
-                    {% endif %}
-                    <div class="list-group list-group-flush mb-3">
-                    {% for path, title in previous_paths_and_titles %}
-                        <a class="list-group-item list-group-item-action border-left-0 border-right-0 rounded-0" href={{path}}>{{title}}</a>
-                    {% endfor %}
                     </div>
                 </div>
             </div>
         </div>
     </div>
 </div>
+
+<script>
+// Load and display history from localStorage when the modal is opened
+document.addEventListener('DOMContentLoaded', function() {
+    // Get the modal element
+    const historyModal = document.getElementById('{{ path_id }}');
+    
+    // Add event listener for when the modal is shown
+    $(historyModal).on('show.bs.modal', function() {
+        loadHistoryFromLocalStorage();
+    });
+    
+    // Function to load history from localStorage
+    function loadHistoryFromLocalStorage() {
+        const container = document.getElementById('history-items-container');
+        
+        try {
+            // Get history from localStorage
+            const paths = JSON.parse(localStorage.getItem('previous_paths') || '[]');
+            const titles = JSON.parse(localStorage.getItem('previous_paths_titles') || '[]');
+            
+            // Clear the container
+            container.innerHTML = '';
+            
+            // If no history, show message
+            if (paths.length === 0 || titles.length === 0) {
+                container.innerHTML = '<p class="text-muted my-4">No course sections viewed yet.</p>';
+                return;
+            }
+            
+            // Create list group
+            const listGroup = document.createElement('div');
+            listGroup.className = 'list-group list-group-flush mb-3';
+            
+            // Add each history item
+            for (let i = 0; i < Math.min(paths.length, titles.length); i++) {
+                const link = document.createElement('a');
+                link.className = 'list-group-item list-group-item-action border-left-0 border-right-0 rounded-0';
+                link.href = paths[i];
+                link.textContent = titles[i];
+                listGroup.appendChild(link);
+            }
+            
+            container.appendChild(listGroup);
+        } catch (e) {
+            console.error('Error loading history from localStorage:', e);
+            container.innerHTML = '<p class="text-muted my-4">Error loading history.</p>';
+        }
+    }
+});
+</script>

--- a/tcf_website/templates/course/course.html
+++ b/tcf_website/templates/course/course.html
@@ -1,7 +1,13 @@
 {% extends "base/base.html" %}
 {% load static %}
 
-{% block title %}{{course.code}} - theCourseForum{% endblock %}
+{% block title %}{{course.code}} | theCourseForum{% endblock %}
+
+{% block page_metadata %}
+<!-- Course meta data for localStorage -->
+{% if course_code %}<meta name="course-code" content="{{ course_code }}">{% endif %}
+{% if course_title %}<meta name="course-title" content="{{ course_title }}">{% endif %}
+{% endblock %}
 
 {% block styles %}
     <link rel="stylesheet" href="{% static 'common/rating_card.css' %}"/>

--- a/tcf_website/templates/course/course_professor.html
+++ b/tcf_website/templates/course/course_professor.html
@@ -1,7 +1,14 @@
 {% extends "base/base.html" %}
 {% load static %}
 
-{% block title %}{{course.code}} - {{instructor.full_name}} - theCourseForum{% endblock %}
+{% block title %}{{course.code}} - {{instructor.full_name}} | theCourseForum{% endblock %}
+
+{% block page_metadata %}
+<!-- Course and instructor meta data for localStorage -->
+{% if course_code %}<meta name="course-code" content="{{ course_code }}">{% endif %}
+{% if course_title %}<meta name="course-title" content="{{ course_title }}">{% endif %}
+{% if instructor_fullname %}<meta name="instructor-name" content="{{ instructor_fullname }}">{% endif %}
+{% endblock %}
 
 {% block styles %}
     <link rel="stylesheet" href="{% static 'course/course_professor.css' %}"/>

--- a/tcf_website/views/browse.py
+++ b/tcf_website/views/browse.py
@@ -159,10 +159,8 @@ def course_view(
     if not instructor_recency:
         instructor_recency = str(Semester.latest())
 
-    # Clears previously saved course information
-    request.session["course_code"] = None
-    request.session["course_title"] = None
-    request.session["instructor_fullname"] = None
+    # No longer storing in session - client-side storage will handle this
+    # (JavaScript now handles this via localStorage)
 
     if is_club:
         # 'mnemonic' is actually category_slug, 'course_number' is club.id
@@ -204,9 +202,8 @@ def course_view(
             (club.name, None, True),
         ]
 
-        # Save club info to session
-        request.session["course_code"] = f"{club.category.slug} {club.id}"
-        request.session["course_title"] = club.name
+        # Pass club info to template for meta tags
+        club_code = f"{club.category.slug} {club.id}"
 
         return render(
             request,
@@ -218,6 +215,8 @@ def course_view(
                 "paginated_reviews": paginated_reviews,
                 "sort_method": request.GET.get("method", ""),
                 "breadcrumbs": breadcrumbs,
+                "course_code": club_code,
+                "course_title": club.name,
             },
         )
 
@@ -280,10 +279,8 @@ def course_view(
         (course.code, None, True),
     ]
 
-    # Saves information of course to session for recently viewed modal
-    request.session["course_code"] = course.code()
-    request.session["course_title"] = course.title
-    request.session["instructor_fullname"] = None
+    # Pass course info to template for meta tags
+    # (JavaScript will retrieve these from meta tags)
 
     return render(
         request,
@@ -298,6 +295,8 @@ def course_view(
             "sortby": sortby,
             "order": order,
             "active_instructor_recency": instructor_recency,
+            "course_code": course.code(),
+            "course_title": course.title,
         },
     )
 
@@ -409,9 +408,8 @@ def course_instructor(request, course_id, instructor_id, method="Default"):
             "times": times,
         }
 
-    request.session["course_code"] = course.code()
-    request.session["course_title"] = course.title
-    request.session["instructor_fullname"] = instructor.full_name
+    # No longer storing in session
+    # Course and instructor info is passed to template context for meta tags
 
     # QA Data
     questions = Question.objects.filter(course=course_id, instructor=instructor_id)
@@ -439,6 +437,9 @@ def course_instructor(request, course_id, instructor_id, method="Default"):
             "answers": answers,
             "sort_method": method,
             "sem_code": section_last_taught.semester.number,
+            "course_code": course.code(),
+            "course_title": course.title,
+            "instructor_fullname": instructor.full_name,
         },
     )
 

--- a/tcf_website/views/index.py
+++ b/tcf_website/views/index.py
@@ -26,10 +26,8 @@ def index(request):
         {
             "executive_team": team_info["executive_team"],
             "FAQs": faqs,
-            "visited": request.session.get("visited", False),
         },
     )
-    request.session["visited"] = True
     return response
 
 

--- a/tcf_website/views/schedule.py
+++ b/tcf_website/views/schedule.py
@@ -330,10 +330,8 @@ def edit_schedule(request):
         schedule.name = request.POST["schedule_name"]
         schedule.save()
 
-    # Store deleted courses in session before deleting them
     deleted_courses = request.POST.getlist("removed_course_ids[]")
     if deleted_courses:
-        request.session["deleted_courses"] = deleted_courses
         ScheduledCourse.objects.filter(id__in=deleted_courses).delete()
 
     messages.success(request, f"Successfully made changes to {schedule.name}")

--- a/tcf_website/views/search.py
+++ b/tcf_website/views/search.py
@@ -90,8 +90,8 @@ def search(request):
         "min_gpa": request.GET.get("min_gpa"),
     }
 
-    # Save filters to session
-    request.session["search_filters"] = filters
+    # Filters are now managed by localStorage in the browser
+    # No need to save them to the session anymore
 
     instructors = []
     courses_first = True


### PR DESCRIPTION
move all django_session to localStorage (i.e. filters, recently viewed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Recently viewed courses and instructors are now tracked and displayed using your browser’s localStorage, ensuring faster and more consistent history across sessions.
  - Search filters persist across page reloads by saving your filter selections in localStorage.

- **Improvements**
  - Enhanced styling and layout for the recently viewed history modal for a cleaner, more consistent appearance.
  - Page titles now use a vertical bar ("|") separator for improved readability.
  - Added metadata tags to course, instructor, and club pages to support client-side features.
  - History management moved fully to client-side localStorage with cookies maintained only for backward compatibility.
  - Search filters UI now fully synchronizes with localStorage, including a clear/reset function for filters.
  - Removed server-side session storage usage for search filters, visit tracking, and deleted course IDs to streamline data handling.

- **Bug Fixes**
  - Removed reliance on server-side session storage for history and filters, reducing potential inconsistencies and improving privacy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->