### PR TITLE
Optimize page size by removing search bar filters

### DIFF
--- a/tcf_website/static/search/searchbar.css
+++ b/tcf_website/static/search/searchbar.css
@@ -202,34 +202,6 @@
   pointer-events: none;
 }
 
-.form-check-subjects,
-.form-check-disciplines {
-  margin-top: 1.2% !important;
-  align-self: start !important;
-}
-
-.subject-list,
-.discipline-list {
-  max-height: 150px;
-  overflow-y: auto;
-  border: 1px solid #cbd5e0;
-  border-radius: 8px;
-  padding: 0.75rem;
-  margin-top: 0.5rem;
-  background: #fff;
-  min-height: 200px;
-}
-
-.form-check.subdepartment-label,
-.form-check.discipline-label {
-  display: flex;
-  justify-content: flex-start;
-}
-
-.discipline-list {
-  /* removed max-height: 250px; */
-}
-
 .search-container {
   position: relative;
 }
@@ -266,12 +238,6 @@
   font-size: 0.9rem;
 }
 
-.subject-list,
-.discipline-list {
-  scrollbar-width: thin;
-  scrollbar-color: #cbd5e0 transparent;
-}
-
 .btn-custom {
   background-color: #d75626;
   border: 2px solid #d75626;
@@ -291,15 +257,4 @@
   box-shadow: none !important;
   outline: none !important;
   border: 2px solid #b4441d;
-}
-
-.subject-list::-webkit-scrollbar,
-.discipline-list::-webkit-scrollbar {
-  width: 4px;
-}
-
-.subject-list::-webkit-scrollbar-thumb,
-.discipline-list::-webkit-scrollbar-thumb {
-  background-color: #cbd5e0;
-  border-radius: 2px;
 }

--- a/tcf_website/templates/search/searchbar.html
+++ b/tcf_website/templates/search/searchbar.html
@@ -136,61 +136,6 @@
                 </div>
               </div>
             </div>
-            
-            <!-- List of subjects -->
-            <div class="filter-grid">
-              <div class="filter-section">
-                <h6 class="filter-header">
-                  Subject
-                </h6>
-                <div class="search-container">
-                  <i class="fa fa-search search-icon"></i>
-                  <input type="text" class="form-control" id="subject-search" placeholder="Search subjects...">
-                </div>
-                <div class="subject-list">
-                  {% for subdept in subdepartments %}
-                    <div class="form-check subdepartment-label">
-                      <input 
-                        class="form-check-input form-check-subjects" 
-                        type="checkbox" 
-                        id="subject-{{ subdept.mnemonic }}" 
-                        name="subdepartment" 
-                        value="{{ subdept.mnemonic }}"
-                      >
-                      <label class="form-check-label" for="subject-{{ subdept.mnemonic }}">
-                        {{ subdept.mnemonic }} - {{ subdept.name }}
-                      </label>
-                    </div>
-                  {% endfor %}
-                </div>
-              </div>
-              <!-- List of disciplines -->
-              <div class="filter-section">
-                <h6 class="filter-header">
-                  Discipline
-                </h6>
-                <div class="search-container">
-                  <i class="fa fa-search search-icon"></i>
-                  <input type="text" class="form-control" id="discipline-search" placeholder="Search disciplines...">
-                </div>
-                <div class="discipline-list">
-                  {% for discipline in disciplines %}
-                    <div class="form-check discipline-label">
-                      <input 
-                        class="form-check-input form-check-disciplines" 
-                        type="checkbox" 
-                        id="discipline-{{ discipline.name|slugify }}" 
-                        name="discipline" 
-                        value="{{ discipline.name }}"
-                      >
-                      <label class="form-check-label" for="discipline-{{ discipline.name|slugify }}">
-                        {{ discipline.name }}
-                      </label>
-                    </div>
-                  {% endfor %}
-                </div>
-              </div>
-            </div>
           </div>
   
           <!-- Action buttons -->


### PR DESCRIPTION
## GitHub Issues addressed

- N/A

## What I did

- Removed filtering by subject and discipline in the search bar

## Screenshots

- Before
<img width="888" height="678" alt="Screenshot 2025-09-28 at 3 46 59 PM" src="https://github.com/user-attachments/assets/21a6225e-bcdd-46b8-94b8-54c606fd5a0d" />

- After
<img width="871" height="421" alt="Screenshot 2025-09-28 at 3 47 07 PM" src="https://github.com/user-attachments/assets/3298c81c-c80b-483e-b692-22cf9b6cdfa9" />

## Testing

- Checkout this commit and run docker compose up

## Questions/Discussions/Notes

- Priority for this PR is to remove the feature to save on page size - 50kb vs 250kb sent to users matters a lot, and should slash our data transfer out costs. 
- Adding back this feature should be saved for later, and should be done in a way that doesn't transfer this much data.
- We should pay attention to if people are even using this or not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed “Subject” and “Discipline” filters from the search filter panel, simplifying the filtering experience while keeping other filters (day/time, availability, GPA, etc.) unchanged.
- Style
  - Cleaned up related styles by removing list and custom scrollbar styling associated with the removed filters, resulting in a leaner, more consistent UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->