### PR TITLE
increased client cache timer from a day to a year and changes static file generation into S3ManifestStaticStorage for cache busting strategy

### DIFF
--- a/tcf_core/settings/base.py
+++ b/tcf_core/settings/base.py
@@ -73,7 +73,8 @@ else:
     AWS_S3_REGION_NAME = env.str("AWS_S3_REGION_NAME", default="us-east-1")
     AWS_S3_CUSTOM_DOMAIN = f"{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com"
     AWS_DEFAULT_ACL = None
-    AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "max-age=86400"}
+    AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "max-age=31536000"}  # 1 year cache
+    STATIC_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/static/"
 
     ALLOWED_HOSTS.extend(
         [
@@ -89,7 +90,7 @@ else:
             "OPTIONS": {},
         },
         "staticfiles": {
-            "BACKEND": "storages.backends.s3.S3Storage",
+            "BACKEND": "storages.backends.s3.S3ManifestStaticStorage",
         },
     }
 

--- a/tcf_core/settings/base.py
+++ b/tcf_core/settings/base.py
@@ -73,7 +73,6 @@ else:
     AWS_S3_REGION_NAME = env.str("AWS_S3_REGION_NAME", default="us-east-1")
     AWS_S3_CUSTOM_DOMAIN = f"{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com"
     AWS_DEFAULT_ACL = None
-    AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "max-age=31536000"}  # 1 year cache
     STATIC_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/static/"
 
     ALLOWED_HOSTS.extend(

--- a/tcf_core/settings/base.py
+++ b/tcf_core/settings/base.py
@@ -75,7 +75,6 @@ else:
     AWS_DEFAULT_ACL = None
     AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "max-age=31536000"}  # 1 year cache
     STATIC_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/static/"
-    AWS_LOCATION = "static"
 
     ALLOWED_HOSTS.extend(
         [
@@ -89,12 +88,14 @@ else:
         "default": {
             "BACKEND": "storages.backends.s3.S3Storage",
             "OPTIONS": {
+                "location": "media",
                 "object_parameters": {"CacheControl": "max-age=86400"},  # 1 day for media
             },
         },
         "staticfiles": {
             "BACKEND": "storages.backends.s3.S3ManifestStaticStorage",
             "OPTIONS": {
+                "location": "static",
                 "object_parameters": {"CacheControl": "max-age=31536000"},  # 1 year for static
             },
         },

--- a/tcf_core/settings/base.py
+++ b/tcf_core/settings/base.py
@@ -75,6 +75,7 @@ else:
     AWS_DEFAULT_ACL = None
     AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "max-age=31536000"}  # 1 year cache
     STATIC_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/static/"
+    AWS_LOCATION = "static"
 
     ALLOWED_HOSTS.extend(
         [
@@ -87,10 +88,15 @@ else:
     STORAGES = {
         "default": {
             "BACKEND": "storages.backends.s3.S3Storage",
-            "OPTIONS": {},
+            "OPTIONS": {
+                "object_parameters": {"CacheControl": "max-age=86400"},  # 1 day for media
+            },
         },
         "staticfiles": {
             "BACKEND": "storages.backends.s3.S3ManifestStaticStorage",
+            "OPTIONS": {
+                "object_parameters": {"CacheControl": "max-age=31536000"},  # 1 year for static
+            },
         },
     }
 


### PR DESCRIPTION
## GitHub Issues addressed

- This PR closes

## What I did

- Changed the original `AWS_S3_OBJECT_PARAMETERS` timer from a day to a year
- To prevent newly generated static files not being fetched due to client caching, changed the original `storages.backends.s3.S3Storage` into `storages.backends.s3.S3ManifestStaticStorage` to generate a unique file hash when collecting static

Originally, if the time between two requests are longer than a day, it will refetch the static files again from S3 which is not very optimal. This change should change this refetch interval to a year.

In order to make sure that updated static files are being refetched after a new deployment, the S3ManifestStaticStorage will create a file hash in the file name. For example, base.css might be hashed into base.a1b2c3d4.css afterward. This should make sure that the frontend browser to refetch the static file if changed.

## Online resources for documentation:

https://django-storages.readthedocs.io/en/1.11.1/backends/amazon-S3.html
https://docs.djangoproject.com/en/3.1/ref/contrib/staticfiles/#manifeststaticfilesstorage

## Screenshots

- Before
- After

## Testing

- A brief explanation of tests done/written or how reviewers can test your work

## Questions/Discussions/Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Static assets are now served from a dedicated S3 static URL/domain.

* **Performance Improvements**
  * Static assets use long-term caching (365 days) to speed repeat visits and employ manifest-backed handling for reliable cache busting.
  * Media files use shorter caching (24 hours) so updates appear promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->