### PR TITLE
Browse advanced search: fix mobile overflow and checkbox layout

### DIFF
--- a/tcf_website/static/css/site/pages/browse.css
+++ b/tcf_website/static/css/site/pages/browse.css
@@ -476,11 +476,11 @@
   gap: var(--space-3);
 }
 
-/* Days & times: desktop side-by-side; mobile stacked in max-width block below */
+/* Days & times combined row */
 .advanced-search__days-times {
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-start;
+  align-items: center;
   gap: var(--space-4);
 }
 
@@ -495,14 +495,8 @@
   flex-shrink: 0;
 }
 
-.advanced-search__times .advanced-search__field {
-  min-width: 0;
-}
-
 .advanced-search__times .advanced-search__field input {
   width: 8rem;
-  max-width: 100%;
-  min-width: 0;
 }
 
 @media (max-width: 767px) {
@@ -510,58 +504,26 @@
     grid-template-columns: 1fr;
   }
 
-  /* Fieldsets + native time inputs have large min-widths; constrain to avoid overflow */
-  .advanced-search {
-    min-width: 0;
-    max-width: 100%;
-  }
-
   .advanced-search__fieldset {
     min-width: 0;
-    max-width: 100%;
   }
 
-  /* One checkbox per row (discipline + days) */
   .advanced-search__days {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: var(--space-2);
+    flex-direction: column;
+    flex-wrap: nowrap;
   }
 
   .advanced-search__days-times {
     flex-direction: column;
     align-items: stretch;
-    flex-wrap: nowrap;
-    gap: var(--space-3);
-    width: 100%;
-    max-width: 100%;
-    min-width: 0;
   }
 
-  .advanced-search__days-times .advanced-search__days {
-    flex: none;
-    min-width: 0;
-    width: 100%;
-  }
-
-  /* Stack Start / End — two <input type="time"> in a row overflows on phones */
   .advanced-search__times {
     flex-direction: column;
-    width: 100%;
-    max-width: 100%;
-    min-width: 0;
-    gap: var(--space-3);
-  }
-
-  .advanced-search__times .advanced-search__field {
-    width: 100%;
-    min-width: 0;
   }
 
   .advanced-search__times .advanced-search__field input {
     width: 100%;
-    max-width: 100%;
-    min-width: 0;
   }
 }
 

--- a/tcf_website/static/css/site/pages/browse.css
+++ b/tcf_website/static/css/site/pages/browse.css
@@ -341,12 +341,6 @@
   margin-bottom: var(--space-4);
 }
 
-@media (max-width: 767px) {
-  .advanced-search__grid {
-    grid-template-columns: 1fr;
-  }
-}
-
 @media (min-width: 768px) and (max-width: 1023px) {
   .advanced-search__grid {
     grid-template-columns: repeat(2, 1fr);
@@ -482,11 +476,11 @@
   gap: var(--space-3);
 }
 
-/* Days & times combined row */
+/* Days & times: desktop side-by-side; mobile stacked in max-width block below */
 .advanced-search__days-times {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--space-4);
 }
 
@@ -501,33 +495,73 @@
   flex-shrink: 0;
 }
 
+.advanced-search__times .advanced-search__field {
+  min-width: 0;
+}
+
 .advanced-search__times .advanced-search__field input {
   width: 8rem;
+  max-width: 100%;
+  min-width: 0;
 }
 
 @media (max-width: 767px) {
+  .advanced-search__grid {
+    grid-template-columns: 1fr;
+  }
+
+  /* Fieldsets + native time inputs have large min-widths; constrain to avoid overflow */
+  .advanced-search {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .advanced-search__fieldset {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  /* One checkbox per row (discipline + days) */
+  .advanced-search__days {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-2);
+  }
+
   .advanced-search__days-times {
     flex-direction: column;
     align-items: stretch;
+    flex-wrap: nowrap;
+    gap: var(--space-3);
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
   }
 
   .advanced-search__days-times .advanced-search__days {
     flex: none;
-    min-width: unset;
-  }
-
-  .advanced-search__times {
-    flex-shrink: 1;
+    min-width: 0;
     width: 100%;
   }
 
+  /* Stack Start / End — two <input type="time"> in a row overflows on phones */
+  .advanced-search__times {
+    flex-direction: column;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    gap: var(--space-3);
+  }
+
   .advanced-search__times .advanced-search__field {
-    flex: 1;
+    width: 100%;
     min-width: 0;
   }
 
   .advanced-search__times .advanced-search__field input {
     width: 100%;
+    max-width: 100%;
+    min-width: 0;
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaced the previous verbose mobile rules with a **short** block:

- `fieldset { min-width: 0 }` — stops the Days & Times box from refusing to shrink (common fieldset overflow issue).
- `days-times` → column on small screens — days above times.
- `times` → column + `input { width: 100% }` — Start/End stacked so native time pickers don’t overflow.
- `days` → `flex-direction: column; flex-wrap: nowrap` — one checkbox per row for discipline + weekdays (no ragged wrap).

Desktop styles are back to the original simple flex row + `8rem` time inputs.

## File

- `tcf_website/static/css/site/pages/browse.css`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9aa61ac6-0050-4f37-9a9a-9e47f9238e55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9aa61ac6-0050-4f37-9a9a-9e47f9238e55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

