### PR TITLE
Fix search bar formatting

### DIFF
--- a/tcf_website/static/css/site/components/search_bar.css
+++ b/tcf_website/static/css/site/components/search_bar.css
@@ -32,8 +32,8 @@
 .search-bar__input {
   width: 100%;
   height: 2.25rem;
-  padding-left: var(--space-9); 
-  padding-right: 5rem; /* Space for actions group */
+  padding-left: var(--space-9);
+  padding-right: 2.75rem; /* Space for actions group */
   appearance: none;
   -webkit-appearance: none;
   
@@ -106,7 +106,7 @@
 
   .header .search-bar__input {
     font-size: var(--text-base);
-    padding-right: 3.5rem;
+    padding-right: 2.75rem;
   }
 
   .header .search-bar__actions-group {

--- a/tcf_website/static/css/site/components/search_bar.css
+++ b/tcf_website/static/css/site/components/search_bar.css
@@ -195,9 +195,6 @@
 }
 
 .autocomplete-group-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
   padding: var(--space-1) var(--space-4);
   font-size: var(--text-xs);
   font-weight: var(--font-bold);
@@ -205,13 +202,6 @@
   letter-spacing: var(--tracking-wide);
   color: var(--primary);
   opacity: 0.8;
-}
-
-.autocomplete-group-header__hint {
-  color: var(--fg-subtle);
-  font-weight: var(--font-normal);
-  letter-spacing: normal;
-  text-transform: none;
 }
 
 .autocomplete-item {

--- a/tcf_website/static/js/site/lib/search_bar.js
+++ b/tcf_website/static/js/site/lib/search_bar.js
@@ -150,6 +150,11 @@ window.addArrowKeyNav = addArrowKeyNav;
           })
           .then(function (html) {
             autocompleteContainer.innerHTML = html;
+            autocompleteContainer
+              .querySelectorAll(".autocomplete-item__link")
+              .forEach(function (link) {
+                link.setAttribute("tabindex", "-1");
+              });
             autocompleteContainer.hidden = false;
           })
           .catch(function (err) {
@@ -170,7 +175,8 @@ window.addArrowKeyNav = addArrowKeyNav;
     addArrowKeyNav(
       searchInput,
       autocompleteContainer,
-      ".autocomplete-item__link, .autocomplete-item__title",
+      ".autocomplete-item__link",
+      { upLoops: true, downLoops: true },
     );
   }
 

--- a/tcf_website/templates/site/catalog/components/_advanced_search_form.html
+++ b/tcf_website/templates/site/catalog/components/_advanced_search_form.html
@@ -13,7 +13,7 @@
             {% include "site/common/components/_combo_dropdown.html" with combo_name="semester" combo_choices=form.semester.field.choices combo_selected=form.semester.value combo_aria_label="Term" %}
         </div>
         <div class="advanced-search__field">
-            <label>Department</label>
+            <label>School</label>
             {% include "site/common/components/_combo_dropdown.html" with combo_name="school" combo_choices=form.school.field.choices combo_selected=form.school.value combo_aria_label="School" %}
         </div>
         <div class="advanced-search__field">

--- a/tcf_website/templates/site/common/components/_autocomplete_dropdown.html
+++ b/tcf_website/templates/site/common/components/_autocomplete_dropdown.html
@@ -11,7 +11,7 @@
     {% else %}
         <ul class="autocomplete-list" role="listbox">
             <li class="autocomplete-group-header" role="presentation">
-                Clubs <span class="autocomplete-group-header__hint">Tab to select</span>
+                Clubs <span class="autocomplete-group-header__hint">↑↓ to navigate</span>
             </li>
             {% for club in clubs %}
                 <li class="autocomplete-item" role="option">
@@ -36,7 +36,7 @@
         {% if courses_first %}
             {% if courses %}
                 <li class="autocomplete-group-header" role="presentation">
-                    Courses <span class="autocomplete-group-header__hint">Tab to select</span>
+                    Courses <span class="autocomplete-group-header__hint">↑↓ to navigate</span>
                 </li>
                 {% for course in courses %}
                     <li class="autocomplete-item" role="option">
@@ -72,7 +72,7 @@
         {% else %}
             {% if instructors and not autocomplete_action %}
                 <li class="autocomplete-group-header" role="presentation">
-                    Instructors <span class="autocomplete-group-header__hint">Tab to select</span>
+                    Instructors <span class="autocomplete-group-header__hint">↑↓ to navigate</span>
                 </li>
                 {% for instructor in instructors %}
                     <li class="autocomplete-item" role="option">

--- a/tcf_website/templates/site/common/components/_autocomplete_dropdown.html
+++ b/tcf_website/templates/site/common/components/_autocomplete_dropdown.html
@@ -11,7 +11,7 @@
     {% else %}
         <ul class="autocomplete-list" role="listbox">
             <li class="autocomplete-group-header" role="presentation">
-                Clubs <span class="autocomplete-group-header__hint">↑↓ to navigate</span>
+                Clubs
             </li>
             {% for club in clubs %}
                 <li class="autocomplete-item" role="option">
@@ -36,7 +36,7 @@
         {% if courses_first %}
             {% if courses %}
                 <li class="autocomplete-group-header" role="presentation">
-                    Courses <span class="autocomplete-group-header__hint">↑↓ to navigate</span>
+                    Courses
                 </li>
                 {% for course in courses %}
                     <li class="autocomplete-item" role="option">
@@ -72,7 +72,7 @@
         {% else %}
             {% if instructors and not autocomplete_action %}
                 <li class="autocomplete-group-header" role="presentation">
-                    Instructors <span class="autocomplete-group-header__hint">↑↓ to navigate</span>
+                    Instructors
                 </li>
                 {% for instructor in instructors %}
                     <li class="autocomplete-item" role="option">

--- a/tcf_website/templates/site/common/components/_autocomplete_dropdown.html
+++ b/tcf_website/templates/site/common/components/_autocomplete_dropdown.html
@@ -10,9 +10,7 @@
         </ul>
     {% else %}
         <ul class="autocomplete-list" role="listbox">
-            <li class="autocomplete-group-header" role="presentation">
-                Clubs
-            </li>
+            <li class="autocomplete-group-header" role="presentation">Clubs</li>
             {% for club in clubs %}
                 <li class="autocomplete-item" role="option">
                     <a href="{% if autocomplete_action == 'review' %}{% mode_url request 'new_review' mode='clubs' query_club=club.id %}{% else %}{% mode_url request 'club' category_slug=club.category_slug club_id=club.id mode='clubs' %}{% endif %}"
@@ -35,9 +33,7 @@
     <ul class="autocomplete-list" role="listbox">
         {% if courses_first %}
             {% if courses %}
-                <li class="autocomplete-group-header" role="presentation">
-                    Courses
-                </li>
+                <li class="autocomplete-group-header" role="presentation">Courses</li>
                 {% for course in courses %}
                     <li class="autocomplete-item" role="option">
                         {% if autocomplete_action == 'schedule' %}
@@ -71,9 +67,7 @@
             {% endif %}
         {% else %}
             {% if instructors and not autocomplete_action %}
-                <li class="autocomplete-group-header" role="presentation">
-                    Instructors
-                </li>
+                <li class="autocomplete-group-header" role="presentation">Instructors</li>
                 {% for instructor in instructors %}
                     <li class="autocomplete-item" role="option">
                         <a href="{% url 'instructor' instructor_id=instructor.id %}"


### PR DESCRIPTION
## What I did

- improved search bar visual; also changed "department" to "school" on browse page since that's what it's actually filtering by

## Screenshots

- Before
<img width="277" height="38" alt="Screenshot 2026-04-10 at 12 54 03 PM" src="https://github.com/user-attachments/assets/e48dd203-1865-4eeb-8fc8-291b44de1b82" />

- After
<img width="267" height="40" alt="Screenshot 2026-04-10 at 12 53 48 PM" src="https://github.com/user-attachments/assets/265558d8-84e7-42af-89a9-13c27e5f228d" />

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced keyboard navigation in the autocomplete dropdown, including more reliable arrow-key behavior and focus handling.
  * Optimized search bar spacing to improve alignment with the action controls.
  * Clarified the advanced search form by renaming the school dropdown label.
  * Updated autocomplete group hint text to reflect keyboard navigation (↑/↓).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->