### PR TITLE
fix: notify user when resetting password with unregistered email (#1251)

### DIFF
--- a/tcf_website/templates/site/auth/forgot_password.html
+++ b/tcf_website/templates/site/auth/forgot_password.html
@@ -1,0 +1,38 @@
+{% extends "site/common/base.html" %}
+{% load static %}
+{% block title %}
+    Forgot Password – theCourseForum
+{% endblock title %}
+{% block content %}
+    <div style="max-width: 440px; margin: 4rem auto; padding: 0 1rem;">
+        <h1 class="mb-4">Reset your password</h1>
+        {% if messages %}
+            {% for message in messages %}
+                <div class="alert {{ message.tags }} mb-4" role="alert">{{ message }}</div>
+            {% endfor %}
+        {% endif %}
+        <p class="text-muted mb-4">
+            Enter the email address linked to your theCourseForum account and we will send you a
+            password reset link.
+        </p>
+        <form method="post">
+            {% csrf_token %}
+            <div class="mb-4">
+                <label for="email" class="form-label">Email address</label>
+                <input type="email"
+                       id="email"
+                       name="email"
+                       class="form-control mt-1"
+                       value="{{ email|default:'' }}"
+                       placeholder="computing_id@virginia.edu"
+                       required
+                       autofocus>
+            </div>
+            <button type="submit" class="btn btn--primary btn--full">Send reset link</button>
+        </form>
+        <p class="text-subtle text-sm mt-4 text-center">
+            Remember your password?
+            <a href="{% url 'login' %}" class="text-primary">Sign in</a>
+        </p>
+    </div>
+{% endblock content %}

--- a/tcf_website/templates/site/common/modals/_login.html
+++ b/tcf_website/templates/site/common/modals/_login.html
@@ -47,6 +47,9 @@
                 </svg>
                 Sign in with UVA Email
             </a>
+            <p class="text-subtle text-xs mt-2 text-center">
+                <a href="{% url 'forgot_password' %}" class="text-primary">Forgot your password?</a>
+            </p>
             <p class="text-subtle text-xs mt-4">
                 By continuing, you agree to our
                 <a href="{% url 'terms' %}" class="text-primary">Terms</a>

--- a/tcf_website/tests/test_auth.py
+++ b/tcf_website/tests/test_auth.py
@@ -1,0 +1,92 @@
+"""Tests for authentication views."""
+
+from unittest.mock import MagicMock, patch
+
+from botocore.exceptions import ClientError
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+User = get_user_model()
+
+
+class ForgotPasswordViewTests(TestCase):
+    """Tests for the forgot_password view."""
+
+    def setUp(self):
+        self.url = reverse("forgot_password")
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="testuser@virginia.edu",
+            password="testpassword",
+            computing_id="testuser",
+        )
+
+    def test_get_renders_form(self):
+        """GET request renders the forgot-password template."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "site/auth/forgot_password.html")
+
+    def test_post_empty_email(self):
+        """POST with no email shows an error."""
+        response = self.client.post(self.url, {"email": ""})
+        self.assertEqual(response.status_code, 200)
+        msg_texts = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("enter your email" in t.lower() for t in msg_texts))
+
+    def test_post_unregistered_email_shows_error(self):
+        """POST with an unknown email shows a 'no account' error."""
+        response = self.client.post(self.url, {"email": "nobody@virginia.edu"})
+        self.assertEqual(response.status_code, 200)
+        msg_texts = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("no account" in t.lower() for t in msg_texts))
+
+    @patch("tcf_website.views.auth.boto3.client")
+    def test_post_registered_email_calls_cognito_and_redirects(self, mock_boto_client):
+        """POST with a registered email calls Cognito and redirects to login."""
+        mock_client = MagicMock()
+        mock_boto_client.return_value = mock_client
+
+        response = self.client.post(self.url, {"email": "testuser@virginia.edu"})
+
+        mock_client.forgot_password.assert_called_once()
+        self.assertRedirects(response, reverse("login"))
+
+    @patch("tcf_website.views.auth.boto3.client")
+    def test_post_cognito_user_not_found_shows_error(self, mock_boto_client):
+        """UserNotFoundException from Cognito shows a 'no account' error."""
+        mock_client = MagicMock()
+        mock_boto_client.return_value = mock_client
+        mock_client.forgot_password.side_effect = ClientError(
+            {"Error": {"Code": "UserNotFoundException", "Message": "User not found"}},
+            "ForgotPassword",
+        )
+
+        response = self.client.post(self.url, {"email": "testuser@virginia.edu"})
+
+        self.assertEqual(response.status_code, 200)
+        msg_texts = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("no account" in t.lower() for t in msg_texts))
+
+    @patch("tcf_website.views.auth.boto3.client")
+    def test_post_cognito_other_error_shows_generic_message(self, mock_boto_client):
+        """A non-UserNotFoundException from Cognito shows a generic error."""
+        mock_client = MagicMock()
+        mock_boto_client.return_value = mock_client
+        mock_client.forgot_password.side_effect = ClientError(
+            {"Error": {"Code": "InternalErrorException", "Message": "Internal error"}},
+            "ForgotPassword",
+        )
+
+        response = self.client.post(self.url, {"email": "testuser@virginia.edu"})
+
+        self.assertEqual(response.status_code, 200)
+        msg_texts = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("something went wrong" in t.lower() for t in msg_texts))
+
+    def test_authenticated_user_redirected_to_browse(self):
+        """An authenticated user hitting this view is redirected to browse."""
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        self.assertRedirects(response, reverse("browse"))

--- a/tcf_website/tests/test_auth.py
+++ b/tcf_website/tests/test_auth.py
@@ -17,7 +17,7 @@ class ForgotPasswordViewTests(TestCase):
         self.url = reverse("forgot_password")
         self.user = User.objects.create_user(
             username="testuser",
-            email="testuser@virginia.edu",
+            email="TestUser@virginia.edu",  # mixed-case to verify iexact lookup
             password="testpassword",
             computing_id="testuser",
         )
@@ -48,6 +48,18 @@ class ForgotPasswordViewTests(TestCase):
         mock_client = MagicMock()
         mock_boto_client.return_value = mock_client
 
+        response = self.client.post(self.url, {"email": "testuser@virginia.edu"})
+
+        mock_client.forgot_password.assert_called_once()
+        self.assertRedirects(response, reverse("login"))
+
+    @patch("tcf_website.views.auth.boto3.client")
+    def test_post_mixed_case_email_still_matches(self, mock_boto_client):
+        """Email stored with mixed case is matched case-insensitively."""
+        mock_client = MagicMock()
+        mock_boto_client.return_value = mock_client
+
+        # Stored as TestUser@virginia.edu, submitted lowercase
         response = self.client.post(self.url, {"email": "testuser@virginia.edu"})
 
         mock_client.forgot_password.assert_called_once()

--- a/tcf_website/urls.py
+++ b/tcf_website/urls.py
@@ -108,8 +108,9 @@ urlpatterns = [
         views.schedule_unbookmark,
         name="schedule_unbookmark",
     ),
-    # AUTH URLS
+    # AUTH URLs
     path("login/", views.auth.login, name="login"),
     path("cognito-callback/", views.auth.cognito_callback, name="cognito_callback"),
     path("logout/", views.auth.logout, name="logout"),
+    path("forgot-password/", views.auth.forgot_password, name="forgot_password"),
 ]

--- a/tcf_website/views/__init__.py
+++ b/tcf_website/views/__init__.py
@@ -1,7 +1,7 @@
 """Application views."""
 
 from .account import DeleteProfile, profile, reviews
-from .auth import login, logout
+from .auth import forgot_password, login, logout
 from .catalog import browse, department, search
 from .clubs import club_category, club_view
 from .courses import course_instructor, course_view

--- a/tcf_website/views/auth/__init__.py
+++ b/tcf_website/views/auth/__init__.py
@@ -1,23 +1,37 @@
 """Auth related views."""
 
+import hashlib
+import hmac
 import json
 import logging
 import urllib.parse
 from base64 import b64encode
 
+import boto3
 import requests
+from botocore.exceptions import ClientError
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate
+from django.contrib.auth import get_user_model
 from django.contrib.auth import login as auth_login
 from django.contrib.auth import logout as auth_logout
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseRedirect
-from django.shortcuts import redirect
+from django.shortcuts import redirect, render
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_POST
 
 logger = logging.getLogger(__name__)
+User = get_user_model()
+
+
+def _cognito_secret_hash(username: str) -> str:
+    """Compute SecretHash for Cognito API calls when the app client has a secret."""
+    message = username + settings.COGNITO_APP_CLIENT_ID
+    secret = settings.COGNITO_APP_CLIENT_SECRET.encode("utf-8")
+    digest = hmac.new(secret, msg=message.encode("utf-8"), digestmod=hashlib.sha256).digest()
+    return b64encode(digest).decode()
 
 
 def login(request):
@@ -123,3 +137,58 @@ def logout(request):
     )
 
     return HttpResponseRedirect(cognito_logout_url)
+
+
+def forgot_password(request):
+    """Show a form to request a password reset.
+
+    Validates that the email belongs to a known account before forwarding the
+    request to Cognito, so users receive clear feedback rather than silence.
+    """
+    if request.user.is_authenticated:
+        return redirect("browse")
+
+    if request.method != "POST":
+        return render(request, "site/auth/forgot_password.html")
+
+    email = request.POST.get("email", "").strip().lower()
+
+    if not email:
+        messages.error(request, "Please enter your email address.")
+        return render(request, "site/auth/forgot_password.html")
+
+    if not User.objects.filter(email=email).exists():
+        messages.error(
+            request,
+            "No account is associated with that email address. "
+            "Sign in with your UVA email to create an account.",
+        )
+        return render(request, "site/auth/forgot_password.html", {"email": email})
+
+    try:
+        cognito = boto3.client("cognito-idp", region_name=settings.COGNITO_REGION_NAME)
+        kwargs: dict = {
+            "ClientId": settings.COGNITO_APP_CLIENT_ID,
+            "Username": email,
+        }
+        if settings.COGNITO_APP_CLIENT_SECRET:
+            kwargs["SecretHash"] = _cognito_secret_hash(email)
+        cognito.forgot_password(**kwargs)
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        if code == "UserNotFoundException":
+            messages.error(
+                request,
+                "No account is associated with that email address. "
+                "Sign in with your UVA email to create an account.",
+            )
+        else:
+            logger.exception("Cognito forgot_password error: %s", exc)
+            messages.error(request, "Something went wrong. Please try again later.")
+        return render(request, "site/auth/forgot_password.html", {"email": email})
+
+    messages.success(
+        request,
+        "A password reset link has been sent to your email address. Please check your inbox.",
+    )
+    return redirect("login")

--- a/tcf_website/views/auth/__init__.py
+++ b/tcf_website/views/auth/__init__.py
@@ -157,7 +157,8 @@ def forgot_password(request):
         messages.error(request, "Please enter your email address.")
         return render(request, "site/auth/forgot_password.html")
 
-    if not User.objects.filter(email=email).exists():
+    # Use iexact so mixed-case emails stored from Cognito claims are matched.
+    if not User.objects.filter(email__iexact=email).exists():
         messages.error(
             request,
             "No account is associated with that email address. "


### PR DESCRIPTION
Fixes #1251

## What's happening now

When a user visits the Cognito-hosted forgot-password flow and enters an email that isn't registered, Cognito silently does nothing (its default "prevent user existence errors" mode). The user never gets any email and has no idea why.

## What this PR does

Adds a custom `/forgot-password/` page that intercepts the request before it reaches Cognito:

1. The user enters their email on the new Django page.
2. The view checks whether that email matches any account in the local database (case-insensitive, so mixed-case emails stored from Cognito JWT claims are handled correctly).
3. If no match is found, the user immediately sees: *"No account is associated with that email address. Sign in with your UVA email to create an account."*
4. If a match is found, the view calls `cognito-idp.forgot_password` via boto3 directly, which triggers the reset email. A `UserNotFoundException` from Cognito is treated as a second safety net showing the same message.
5. On success, the user is redirected to the login page with a "check your inbox" confirmation.

A "Forgot your password?" link is also added to the existing login modal.

## A note on design tradeoffs

I might be wrong about this, but I think for a university forum where all accounts are UVA email-based, explicitly telling someone "no account found" is more useful than the vague silence they get today. If the maintainers prefer a generic "if your account exists, we sent a link" message for security reasons, I'm happy to adjust — just let me know and I'll update the success/error paths.

Rate-limiting this endpoint (e.g. with django-ratelimit or a CAPTCHA) would be a sensible follow-up but felt out of scope for this fix.

## Files changed

- `tcf_website/views/auth/__init__.py` — new `forgot_password` view + `_cognito_secret_hash` helper
- `tcf_website/views/__init__.py` — re-exports `forgot_password`
- `tcf_website/urls.py` — `/forgot-password/` URL
- `tcf_website/templates/site/auth/forgot_password.html` — new template
- `tcf_website/templates/site/common/modals/_login.html` — "Forgot your password?" link
- `tcf_website/tests/test_auth.py` — 7 unit tests (GET, empty email, unknown email, mixed-case email, Cognito success, `UserNotFoundException`, generic Cognito error)

---

*This contribution was written with AI assistance (Claude). All logic has been reviewed for correctness. If this direction doesn't fit the project's approach, no problem — happy to close or rework.*