### PR TITLE
Fix zombie task on deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,6 @@ COPY . /app/
 
 RUN chmod +x /app/scripts/container-startup.sh
 
-ENTRYPOINT ["/app/scripts/container-startup.sh"]
+EXPOSE 80
+
+CMD ["/app/scripts/container-startup.sh"]


### PR DESCRIPTION
## What I did

- Fixed release task creation
- Prev version was appending arguments and release task was treated as normal task and never exited

## Testing

Run these commands locally
```
docker build -t tcf-test .
docker run --rm tcf-test bash -c "echo 'release task would run here; exiting cleanly'"
```

- With ENTRYPOINT, it hangs 
- With CMD, it exits as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container startup configuration
  * Added port 80 exposure declaration to Docker image configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thecourseforum/theCourseForum2/pull/1255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->