### PR TITLE
1253 display min char limit for reviews

### DIFF
--- a/tcf_website/templates/site/review/review.html
+++ b/tcf_website/templates/site/review/review.html
@@ -184,7 +184,7 @@
       const characters = text.length;
       countDisplay.textContent = characters + ' characters';
       if (characters < 200) {
-          countDisplay.style.color = 'var(--danger)';
+          countDisplay.style.color = 'Black';
       } else {
           countDisplay.style.color = 'var(--fg-muted)';
       }

--- a/tcf_website/templates/site/review/review.html
+++ b/tcf_website/templates/site/review/review.html
@@ -182,10 +182,12 @@
     textarea.addEventListener('input', function() {
       const text = this.value.trim();
       const characters = text.length;
-      countDisplay.textContent = characters + ' characters';
-      if (characters < 200) {
+      const remainingCharacters = textarea.minLength - characters;
+      if (characters < textarea.minLength) {
+          countDisplay.textContent = remainingCharacters + ' required characters';
           countDisplay.style.color = 'var(--danger)';
       } else {
+          countDisplay.textContent = characters + ' characters';
           countDisplay.style.color = 'var(--fg-muted)';
       }
     });

--- a/tcf_website/templates/site/review/review.html
+++ b/tcf_website/templates/site/review/review.html
@@ -182,9 +182,8 @@
     textarea.addEventListener('input', function() {
       const text = this.value.trim();
       const characters = text.length;
-      const remainingCharacters = textarea.minLength - characters;
       if (characters < textarea.minLength) {
-          countDisplay.textContent = remainingCharacters + ' required characters';
+          countDisplay.textContent = characters + '/' + textarea.minLength + ' required characters';
           countDisplay.style.color = 'var(--danger)';
       } else {
           countDisplay.textContent = characters + ' characters';

--- a/tcf_website/templates/site/review/review.html
+++ b/tcf_website/templates/site/review/review.html
@@ -184,7 +184,7 @@
       const characters = text.length;
       countDisplay.textContent = characters + ' characters';
       if (characters < 200) {
-          countDisplay.style.color = 'Black';
+          countDisplay.style.color = 'var(--danger)';
       } else {
           countDisplay.style.color = 'var(--fg-muted)';
       }


### PR DESCRIPTION
## GitHub Issues addressed

- This PR closes issue 1253. "Style: Display minimum character limit for reviews"

## What I did

- Reviews show the number of required characters, counting down from 200 to 1. Once reaching 200 characters, the character count will count up as normal.
- Changed hard coded value 200 for textarea.minLength
- review.html is the only file modified

## Screenshots

- Before
<img width="543" height="236" alt="image" src="https://github.com/user-attachments/assets/e8e2e1ef-5eae-467b-bba3-88f5425ea8be" />

- After
<img width="528" height="226" alt="image" src="https://github.com/user-attachments/assets/e9e5e77b-03c8-4a46-87fc-c15215b8552b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the live review text counter to use the field’s configured minimum length instead of a fixed threshold.
  * When the input is below the minimum, the counter shows `current/min required characters` and uses an alert (danger) styling.
  * Once the minimum is met or exceeded, it switches back to displaying the current character count in a muted style.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->