### PR TITLE
Prevent reviewing courses for semesters that haven't started yet

### DIFF
--- a/tcf_website/models/models.py
+++ b/tcf_website/models/models.py
@@ -555,6 +555,18 @@ class Semester(models.Model):
         ("SUMMER", "Summer"),
     )
 
+    # First calendar month in which each season's classes begin at UVA. Used to
+    # decide whether a term has actually started (e.g. so a course cannot be
+    # reviewed for a semester that has not happened yet). Unknown/blank seasons
+    # default to a late month so they are treated as not-yet-started within
+    # their own year (conservative — never opens up a future term by mistake).
+    SEASON_START_MONTH = {
+        "JANUARY": 1,
+        "SPRING": 1,
+        "SUMMER": 5,
+        "FALL": 8,
+    }
+
     # Semester year. Required.
     year = models.IntegerField(
         validators=[MinValueValidator(2000), MaxValueValidator(2999)]
@@ -587,6 +599,20 @@ class Semester(models.Model):
     def is_after(self, other_sem):
         """Returns True if semester occurred later than other_semester."""
         return self.number > other_sem.number
+
+    def start_month(self):
+        """First calendar month this term's classes begin (1-12)."""
+        return self.SEASON_START_MONTH.get(self.season, 12)
+
+    def has_started(self, as_of=None):
+        """Return True if this term has begun as of ``as_of`` (default: now).
+
+        Compares by (year, start month) so a semester only becomes reviewable
+        once its classes have actually started, regardless of what future terms
+        happen to be loaded in the database for course registration.
+        """
+        as_of = as_of or timezone.now()
+        return (self.year, self.start_month()) <= (as_of.year, as_of.month)
 
     @staticmethod
     def latest():

--- a/tcf_website/review/forms.py
+++ b/tcf_website/review/forms.py
@@ -37,6 +37,13 @@ class ReviewForm(forms.ModelForm):
         instructor = cleaned_data.get("instructor")
         semester = cleaned_data.get("semester")
 
+        # A course/club can only be reviewed for a term that has actually
+        # started — never a future semester loaded for course registration.
+        if semester and not semester.has_started():
+            raise ValidationError(
+                "You can only review a semester that has already started."
+            )
+
         if club:
             return cleaned_data
 

--- a/tcf_website/review/services.py
+++ b/tcf_website/review/services.py
@@ -1,7 +1,7 @@
 """Review-related queries and small pure helpers."""
 
 from ..models import Instructor
-from ..utils import recent_semesters
+from ..utils import recent_semesters, reviewable_semesters
 
 
 def recent_semester_id_set() -> set[int]:
@@ -10,8 +10,11 @@ def recent_semester_id_set() -> set[int]:
 
 
 def club_semester_choices_payload():
-    """JSON-serializable term rows for club-mode review (inline club pick)."""
-    return [{"id": s.id, "label": str(s)} for s in recent_semesters()]
+    """JSON-serializable term rows for club-mode review (inline club pick).
+
+    Only terms that have already started, so a club cannot be reviewed for a
+    future semester."""
+    return [{"id": s.id, "label": str(s)} for s in reviewable_semesters()]
 
 
 def instructors_for_course_semester(course_id: int, semester_id: int):

--- a/tcf_website/tests/test_review.py
+++ b/tcf_website/tests/test_review.py
@@ -7,10 +7,24 @@ from django.db import IntegrityError
 from django.forms.models import model_to_dict
 from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 
-from ..models import Review, Vote
+from ..models import Review, Section, Semester, Vote
 from ..review.forms import ReviewForm
+from ..utils import semesters_for_course
 from .test_utils import setup, suppress_request_warnings
+
+
+def _future_semester_with_section(course, instructor):
+    """Create a not-yet-started Fall term with a matching section for ``course``."""
+    future_year = timezone.now().year + 1
+    number = int(f"1{future_year % 100}8")  # trailing 8 => Fall (starts in August)
+    semester = Semester.objects.create(year=future_year, season="FALL", number=number)
+    section = Section.objects.create(
+        course=course, semester=semester, sis_section_number=999001
+    )
+    section.instructors.set([instructor])
+    return semester
 
 
 class ReviewFormTests(TestCase):
@@ -185,6 +199,21 @@ class ReviewFormSectionValidationTests(TestCase):
         )
         self.assertFalse(form.is_valid())
 
+    def test_rejects_future_semester(self):
+        """A term that has not started yet cannot be reviewed, even with a section."""
+        future = _future_semester_with_section(self.course, self.instructor)
+        form = ReviewForm(_review_post_data(self.course, self.instructor, future))
+        self.assertFalse(form.is_valid())
+        self.assertIn("started", str(form.errors).lower())
+
+    def test_accepts_started_semester(self):
+        """A term that has already started passes clean()."""
+        # self.semester is Fall 2025, which has already started.
+        form = ReviewForm(
+            _review_post_data(self.course, self.instructor, self.semester)
+        )
+        self.assertTrue(form.is_valid())
+
 
 class ReviewCascadeJsonEndpointsTests(TestCase):
     """XHR helpers for the unified review writer."""
@@ -210,6 +239,23 @@ class ReviewCascadeJsonEndpointsTests(TestCase):
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.content)
         ids = {row["id"] for row in data["semesters"]}
+        self.assertIn(self.semester.pk, ids)
+
+    def test_semesters_excludes_future_terms(self):
+        """A not-yet-started term is never offered as a review option."""
+        future = _future_semester_with_section(self.course, self.instructor)
+
+        # Direct helper used by both the server render and the XHR endpoint.
+        self.assertNotIn(future, list(semesters_for_course(self.course)))
+
+        self.client.force_login(self.user1)
+        response = self.client.get(
+            reverse("review_semester_options"),
+            {"course": self.course.pk},
+        )
+        data = json.loads(response.content)
+        ids = {row["id"] for row in data["semesters"]}
+        self.assertNotIn(future.pk, ids)
         self.assertIn(self.semester.pk, ids)
 
     def test_instructors_bad_request_without_params(self):

--- a/tcf_website/tests/test_semester.py
+++ b/tcf_website/tests/test_semester.py
@@ -1,5 +1,7 @@
 """Tests for Semester model."""
 
+from datetime import datetime
+
 from django.test import TestCase
 
 from ..models import Semester
@@ -52,3 +54,35 @@ class SemesterTestCase(TestCase):
     def test_latest_returns_highest_semester_number(self):
         """``latest()`` picks the term with the greatest SIS number."""
         self.assertEqual(Semester.latest().pk, self.semester.pk)
+
+
+class HasStartedTestCase(TestCase):
+    """Tests for the date-based ``has_started`` gate."""
+
+    # Reference "now": July 8, 2026.
+    AS_OF = datetime(2026, 7, 8)
+
+    def test_past_year_has_started(self):
+        """A term from an earlier year has always started."""
+        sem = Semester(season="FALL", year=2020, number=1208)
+        self.assertTrue(sem.has_started(as_of=self.AS_OF))
+
+    def test_future_year_has_not_started(self):
+        """A term in a later year has not started."""
+        sem = Semester(season="SPRING", year=2030, number=1302)
+        self.assertFalse(sem.has_started(as_of=self.AS_OF))
+
+    def test_fall_this_year_not_started_before_august(self):
+        """Fall 2026 has not started as of July 2026 (classes begin in August)."""
+        sem = Semester(season="FALL", year=2026, number=1268)
+        self.assertFalse(sem.has_started(as_of=self.AS_OF))
+
+    def test_summer_this_year_started_by_july(self):
+        """Summer 2026 has started as of July 2026 (classes begin in May)."""
+        sem = Semester(season="SUMMER", year=2026, number=1266)
+        self.assertTrue(sem.has_started(as_of=self.AS_OF))
+
+    def test_start_month_boundary_is_inclusive(self):
+        """A term is considered started once its start month is reached."""
+        sem = Semester(season="FALL", year=2026, number=1268)
+        self.assertTrue(sem.has_started(as_of=datetime(2026, 8, 1)))

--- a/tcf_website/utils.py
+++ b/tcf_website/utils.py
@@ -2,7 +2,7 @@
 
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-from django.db.models import Q, QuerySet
+from django.db.models import Case, IntegerField, Q, QuerySet, Value, When
 from django.utils import timezone
 from django.utils.http import url_has_allowed_host_and_scheme
 
@@ -30,10 +30,33 @@ def recent_semesters() -> QuerySet:
     )
 
 
-def semesters_for_course(course: Course) -> QuerySet:
-    """Recent-catalog semesters in which ``course`` has at least one section, newest first."""
+def reviewable_semesters() -> QuerySet:
+    """Recent-catalog semesters that have already started, so a course can only
+    be reviewed for a term that has actually happened (never a future term that
+    is merely loaded for course registration)."""
+    now = timezone.now()
+    start_month = Case(
+        *[
+            When(season=season, then=Value(month))
+            for season, month in Semester.SEASON_START_MONTH.items()
+        ],
+        default=Value(12),
+        output_field=IntegerField(),
+    )
     return (
-        recent_semesters().filter(section__course=course).distinct().order_by("-number")
+        recent_semesters()
+        .annotate(start_month=start_month)
+        .filter(Q(year__lt=now.year) | Q(year=now.year, start_month__lte=now.month))
+    )
+
+
+def semesters_for_course(course: Course) -> QuerySet:
+    """Started recent-catalog semesters in which ``course`` has at least one section, newest first."""
+    return (
+        reviewable_semesters()
+        .filter(section__course=course)
+        .distinct()
+        .order_by("-number")
     )
 
 

--- a/tcf_website/views/review/new_review.py
+++ b/tcf_website/views/review/new_review.py
@@ -11,7 +11,7 @@ from ...review.services import (
     club_semester_choices_payload,
     instructors_for_course_semester,
 )
-from ...utils import parse_mode, recent_semesters, semesters_for_course, with_mode
+from ...utils import parse_mode, reviewable_semesters, semesters_for_course, with_mode
 
 
 @login_required
@@ -69,7 +69,7 @@ def _handle_course_review_get(request, mode):
                 "club": None,
                 "instructor": None,
                 "instructors": [],
-                "semesters": recent_semesters(),
+                "semesters": reviewable_semesters(),
                 "review_main_unlocked": False,
             },
         )
@@ -112,7 +112,7 @@ def _handle_course_review_get(request, mode):
 def _handle_club_review_get(request, mode):
     """Handle GET for club reviews."""
     club_id = request.GET.get("club")
-    semesters = recent_semesters()
+    semesters = reviewable_semesters()
 
     if not club_id:
         return render(
@@ -149,7 +149,7 @@ def _handle_club_review_get(request, mode):
 def _render_review_form_with_errors(request, form, is_club, mode):
     """Re-render the form with validation errors."""
     context: dict = {"form": form, "is_club": is_club, "mode": mode}
-    base_semesters = recent_semesters()
+    base_semesters = reviewable_semesters()
 
     if is_club:
         club = form.cleaned_data.get("club")


### PR DESCRIPTION
## GitHub Issues addressed

- This PR closes #1252

## What I did

Reviews could be placed for a course in a **future** semester (e.g. Fall 2026). Root cause: the review semester choices (`recent_semesters()` → `semesters_for_course()`) only had a *lower* year bound, and `ReviewForm.clean()` only validated that a matching `Section` existed. Production loads future-term sections for course registration, so those not-yet-started terms showed up as selectable **and** savable review options. (It didn't reproduce on older local data because that data simply lacked the future terms.)

The fix gates reviewable terms by the **calendar date** rather than by whatever is loaded in the DB (`Semester.latest()`):

- **`Semester.has_started()`** (`models.py`) — new `SEASON_START_MONTH` map + method; a term is "started" once its start month is reached in the current/prior year (Fall→Aug, Summer→May, Spring/January→Jan).
- **`utils.reviewable_semesters()`** — started-only subset of `recent_semesters()` (DB-level `Case/When` filter); `semesters_for_course()` now routes through it. `recent_semesters()` is intentionally left unchanged so the **schedule builder still sees upcoming terms**.
- **`ReviewForm.clean()`** — the real backend gate: rejects a not-yet-started term for both course and club reviews.
- **UI filtering** — the club dropdown (`club_semester_choices_payload`) and the empty-state / error-render semester lists in `new_review.py` now only offer started terms, so users never see an invalid option.

## Screenshots

- Before — "Fall 2026" selectable as a review term; the review saves successfully.
<img width="1438" height="1360" alt="image" src="https://github.com/user-attachments/assets/3ff9daff-5b90-41a4-8d05-b7c69d411309" />

- After — future terms no longer appear in the term dropdown, and are rejected server-side ("You can only review a semester that has already started.") even if forced.
<img width="778" height="503" alt="image" src="https://github.com/user-attachments/assets/5eeb4671-340a-49ab-835f-39b07e5ca6f0" />

## Testing

Verified against a fresh prod dump (contains Fall 2026 = 9,038 sections). As of 2026-07-08: `Fall 2026 has_started=False` → excluded from `reviewable_semesters()` but still present in `recent_semesters()`; `Summer 2026` / `Spring 2026` remain reviewable.

Automated (full suite green — 265 tests):
- `test_semester.HasStartedTestCase` — unit tests for the date gate (past/future year, Fall-before-August, Summer-by-July, start-month boundary).
- `test_review.ReviewFormSectionValidationTests` — form rejects a future term (even with a matching section) and accepts a started term.
- `test_review.ReviewCascadeJsonEndpointsTests` — future terms excluded from `semesters_for_course()` and the `review_semester_options` XHR.

To test manually: pick a course with a Fall 2026 section under My Reviews → New Review; Fall 2026 should not be offered as a term.

## Questions/Discussions/Notes

- Product call: a term becomes reviewable the moment it **starts** (so a summer term in progress is allowed). If we'd rather only allow reviewing a term once it has **ended**, that's a one-line change to the comparison in `has_started()`.
- Season start months are approximate first-of-month values, which is sufficient for a future/past gate; they intentionally don't track exact UVA add/drop dates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Semester choices now only include terms that have already started.
  * Review forms now prevent creating reviews for future semesters.

* **Bug Fixes**
  * Improved semester start-date handling, including season-based start months and boundary-day behavior.
  * Review creation and semester selection now stay consistent across course and club review flows.

* **Tests**
  * Added coverage for semester start checks and future-semester review rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->