### PR TITLE
Exclude django_session data from DB dumps (#979)

### DIFF
--- a/scripts/local_dump.sh
+++ b/scripts/local_dump.sh
@@ -16,6 +16,6 @@ set -e
 echo "--- Creating a dump of the '$DB_NAME' database from container 'tcf_db'..."
 
 
-docker exec tcf_db pg_dump -U "$DB_USER" -d "$DB_NAME" --format=custom --clean > "db/$filename"
+docker exec tcf_db pg_dump -U "$DB_USER" -d "$DB_NAME" --format=custom --clean --exclude-table-data=django_session > "db/$filename"
 
 echo "--- ✅ Successfully created database dump at: db/$filename"

--- a/scripts/prod_dump.sh
+++ b/scripts/prod_dump.sh
@@ -19,6 +19,6 @@ echo "--- Connecting to EC2 instance '$EC2_HOST' to dump database from '$PROD_DB
 
 chmod 400 $PEM_KEY
 
-ssh -i "$PEM_KEY" "$EC2_USER@$EC2_HOST" "PGPASSWORD='$PROD_DB_PASSWORD' pg_dump --host='$PROD_DB_HOST' --username=$PROD_DB_USER --format=custom --clean $PROD_DB_USER" > "db/$filename"
+ssh -i "$PEM_KEY" "$EC2_USER@$EC2_HOST" "PGPASSWORD='$PROD_DB_PASSWORD' pg_dump --host='$PROD_DB_HOST' --username=$PROD_DB_USER --format=custom --clean --exclude-table-data=django_session $PROD_DB_USER" > "db/$filename"
 
 echo "--- ✅ Successfully created remote database dump at: db/$filename"


### PR DESCRIPTION
Closes #979

## Problem
DB backups (`latest.dump`) were bloated (~150MB) because `pg_dump` included the `django_session` table. The app uses the `cached_db` session backend, so sessions are written to Postgres.

## Fix
Added `--exclude-table-data=django_session` to the `pg_dump` command in both `scripts/prod_dump.sh` and `scripts/local_dump.sh`. This drops session **rows** while keeping the table **schema**, so restores recreate an empty-but-valid `django_session`.

## Verification
- `bash -n` on both scripts — clean.
- Confirmed `scripts/reset-db.sh` restore (`pg_restore --no-owner`, `--format=custom`) stays compatible; no application code reads session rows directly.

## Caveats
- A restored DB starts with an empty session table (users re-login) — expected and harmless.
- This does **not** prune the *live* DB's session table (the startup `clearsessions` step was dropped during the Terraform migration). A scheduled `clearsessions` is a reasonable follow-up if live-table growth is a concern.

---
🤖 Implemented with Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated database exports to omit session data from generated backups.
  * Preserved all other dump settings, connection steps, and file output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->