### PR TITLE
Debounce dropdown/accordion arrow toggle mid-animation (#1012)

### DIFF
--- a/tcf_website/templates/site/catalog/browse.html
+++ b/tcf_website/templates/site/catalog/browse.html
@@ -92,14 +92,54 @@
     <script src="{% static 'js/site/browse/browse_live_results.js' %}"></script>
     <script>
 document.addEventListener('DOMContentLoaded', function() {
-  // School accordion toggle
+  // School accordion toggle.
+  // The chevron animates with `transition: transform var(--duration-normal)`
+  // (~200ms). Rapid clicks can re-toggle `is-open` before that transition
+  // finishes, leaving the arrow flipped inconsistently relative to its
+  // animation (issue #1012). Guard against re-toggling while the chevron
+  // transition is in flight: ignore clicks until it settles, clearing the
+  // lock on `transitionend` with a time-based fallback in case the event
+  // never fires (e.g. reduced motion, zero-duration, or off-screen).
+  const ANIMATION_FALLBACK_MS = 300; // >= --duration-normal (200ms)
+
   document.querySelectorAll('.school-header').forEach(header => {
+    const chevron = header.querySelector('.school-header__chevron');
+    let animating = false;
+    let fallbackTimer = null;
+
+    function unlock() {
+      animating = false;
+      if (fallbackTimer !== null) {
+        clearTimeout(fallbackTimer);
+        fallbackTimer = null;
+      }
+    }
+
+    // Clear the lock as soon as the chevron transform finishes.
+    if (chevron) {
+      chevron.addEventListener('transitionend', function(e) {
+        if (e.propertyName === 'transform') {
+          unlock();
+        }
+      });
+    }
+
     header.addEventListener('click', function() {
+      // Ignore clicks while the arrow is still mid-animation.
+      if (animating) {
+        return;
+      }
+      animating = true;
+
       const section = this.parentElement;
       const grid = section.querySelector('.departments-grid');
 
       this.classList.toggle('is-open');
       grid.classList.toggle('is-open');
+
+      // Fallback in case `transitionend` never fires (e.g. no chevron,
+      // reduced motion, or a zeroed transition duration).
+      fallbackTimer = setTimeout(unlock, ANIMATION_FALLBACK_MS);
     });
   });
 });


### PR DESCRIPTION
Closes #1012

## Problem
Rapidly clicking a dropdown/accordion header flipped the chevron arrow inconsistently — a second click landed mid-transition (the chevron animates ~200ms via `--duration-normal`) while the handler did a bare `classList.toggle('is-open')` with no guard, leaving the arrow out of sync with the open/closed state.

## Fix
Added an `is-animating` lockout to the browse-page school accordion (`tcf_website/templates/site/catalog/browse.html`): clicks are ignored while the chevron transition is in flight, released on the chevron's `transitionend` (transform) with a 300ms `setTimeout` fallback for `prefers-reduced-motion`/zero-duration cases. Keyboard/Enter activation is preserved; no new libraries.

## Scope note
The FAQ accordion named in the original report was removed in the v2 UI rewrite. I audited every `rotate(180deg)` arrow in the codebase — the browse school accordion is the only **live, JS-driven** toggle with this race. Intentionally left alone: the header user-menu / recent-items dropdowns (popovers that legitimately close on re-click), native `<details>`/`<summary>` elements (rotation driven by the browser, not JS), and the `.accordion__*` CSS (dead after the v2 rewrite).

## Verification
- Static trace: rapid second click hits the `animating` guard and is ignored until the chevron settles; single-click and keyboard activation are unaffected; the fallback timer guarantees the lock always clears (no deadlock).
- Node `--check` syntax validation of the inline JS block passed.
- No headless-browser run (JS is inline in a Django template) — runtime behavior confirmed by static reasoning.

## Caveat
`.school-header` is a `<div>` with no `tabindex`/`role` today, so it isn't keyboard-focusable — a pre-existing a11y gap left unchanged (out of scope for this fix).

---
🤖 Implemented with Claude Code.
