### PR TITLE
Notify users when resetting password for an unregistered account (#1251)

### DIFF
--- a/tcf_website/templates/site/auth/forgot_password.html
+++ b/tcf_website/templates/site/auth/forgot_password.html
@@ -1,0 +1,39 @@
+{% extends "site/common/base.html" %}
+{% load static %}
+{% block title %}
+    Forgot Password | theCourseForum
+{% endblock title %}
+{% block styles %}
+    <link rel="stylesheet" href="{% static 'css/site/pages/legal.css' %}">
+{% endblock styles %}
+{% block content %}
+    <div class="legal-page">
+        <article class="legal-card">
+            <h1>Reset your password</h1>
+            <p class="text-muted text-sm mb-6">
+                Enter the email address associated with your account and we'll send
+                you a link to reset your password.
+            </p>
+            <form method="post" action="{% url 'forgot_password' %}">
+                {% csrf_token %}
+                <label class="text-sm" for="forgot-password-email">Email address</label>
+                <input id="forgot-password-email"
+                       type="email"
+                       name="email"
+                       class="input mb-6"
+                       required
+                       autocomplete="email"
+                       placeholder="you@virginia.edu"
+                       aria-label="Email address">
+                <button type="submit" class="btn btn--primary btn--lg btn--full">
+                    Send reset link
+                </button>
+            </form>
+            <p class="text-subtle text-xs mt-4">
+                Don't have an account?
+                <a href="{% url 'login' %}" class="text-primary">Sign in with your UVA email</a>
+                to create one.
+            </p>
+        </article>
+    </div>
+{% endblock content %}

--- a/tcf_website/templates/site/auth/forgot_password.html
+++ b/tcf_website/templates/site/auth/forgot_password.html
@@ -25,9 +25,7 @@
                        autocomplete="email"
                        placeholder="you@virginia.edu"
                        aria-label="Email address">
-                <button type="submit" class="btn btn--primary btn--lg btn--full">
-                    Send reset link
-                </button>
+                <button type="submit" class="btn btn--primary btn--lg btn--full">Send reset link</button>
             </form>
             <p class="text-subtle text-xs mt-4">
                 Don't have an account?

--- a/tcf_website/templates/site/common/modals/_login.html
+++ b/tcf_website/templates/site/common/modals/_login.html
@@ -47,6 +47,9 @@
                 </svg>
                 Sign in with UVA Email
             </a>
+            <p class="text-sm mt-4">
+                <a href="{% url 'forgot_password' %}" class="text-primary">Forgot your password?</a>
+            </p>
             <p class="text-subtle text-xs mt-4">
                 By continuing, you agree to our
                 <a href="{% url 'terms' %}" class="text-primary">Terms</a>

--- a/tcf_website/tests/test_auth.py
+++ b/tcf_website/tests/test_auth.py
@@ -1,0 +1,156 @@
+"""Custom forgot-password flow (issue #1251).
+
+Cognito's hosted UI silently no-ops password resets for unknown emails
+(``prevent_user_existence_errors`` is enabled), leaving users with no
+feedback. The ``forgot_password`` view checks the local account table first
+and notifies the user when no account exists, then delegates to Cognito for
+known accounts.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from botocore.exceptions import ClientError
+from django.contrib.messages import get_messages
+from django.test import override_settings
+from django.urls import reverse
+
+from ..views.auth import NO_ACCOUNT_MESSAGE
+from .base import TCFDataTestCase
+
+
+def _messages(response):
+    """Return the flat list of flash message strings on a response."""
+    return [str(m) for m in get_messages(response.wsgi_request)]
+
+
+@override_settings(
+    COGNITO_DOMAIN="https://test-pool.auth.us-east-1.amazoncognito.com",
+    COGNITO_APP_CLIENT_ID="test-client-id",
+    COGNITO_APP_CLIENT_SECRET="test-secret",
+    COGNITO_REGION_NAME="us-east-1",
+)
+class ForgotPasswordTestCase(TCFDataTestCase):
+    """GET renders the form; POST branches on local-account existence."""
+
+    def test_get_renders_form(self):
+        """GET /forgot-password/ renders the reset form."""
+        response = self.client.get(reverse("forgot_password"))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "site/auth/forgot_password.html")
+        self.assertContains(response, 'name="email"')
+
+    @patch("tcf_website.views.auth.boto3.client")
+    def test_empty_email_shows_error_and_does_not_call_cognito(self, mock_client):
+        """Blank email is rejected before any Cognito call."""
+        response = self.client.post(reverse("forgot_password"), {"email": "  "})
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            any("enter your email" in m.lower() for m in _messages(response))
+        )
+        mock_client.assert_not_called()
+
+    @patch("tcf_website.views.auth.boto3.client")
+    def test_unknown_email_shows_no_account_message(self, mock_client):
+        """An email with no local account surfaces the no-account message."""
+        response = self.client.post(
+            reverse("forgot_password"),
+            {"email": "nobody@virginia.edu"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(NO_ACCOUNT_MESSAGE, _messages(response))
+        mock_client.assert_not_called()
+
+    @patch("tcf_website.views.auth.boto3.client")
+    def test_known_email_calls_cognito_and_redirects(self, mock_client):
+        """A known account triggers Cognito ``forgot_password`` and redirects."""
+        cognito = MagicMock()
+        mock_client.return_value = cognito
+
+        response = self.client.post(
+            reverse("forgot_password"),
+            {"email": self.user1.email},
+        )
+
+        self.assertRedirects(
+            response,
+            reverse("login"),
+            fetch_redirect_response=False,
+        )
+        cognito.forgot_password.assert_called_once()
+        kwargs = cognito.forgot_password.call_args.kwargs
+        self.assertEqual(kwargs["ClientId"], "test-client-id")
+        self.assertEqual(kwargs["Username"], self.user1.username)
+        # A client secret is configured, so a SECRET_HASH must be supplied.
+        self.assertIn("SecretHash", kwargs)
+
+    @patch("tcf_website.views.auth.boto3.client")
+    def test_known_email_lookup_is_case_insensitive(self, mock_client):
+        """Casing differences don't hide an existing account."""
+        cognito = MagicMock()
+        mock_client.return_value = cognito
+
+        response = self.client.post(
+            reverse("forgot_password"),
+            {"email": self.user1.email.upper()},
+        )
+
+        self.assertRedirects(
+            response,
+            reverse("login"),
+            fetch_redirect_response=False,
+        )
+        cognito.forgot_password.assert_called_once()
+
+    @override_settings(COGNITO_APP_CLIENT_SECRET="")
+    @patch("tcf_website.views.auth.boto3.client")
+    def test_no_secret_hash_when_client_has_no_secret(self, mock_client):
+        """Without a client secret, ``SECRET_HASH`` is omitted."""
+        cognito = MagicMock()
+        mock_client.return_value = cognito
+
+        self.client.post(
+            reverse("forgot_password"),
+            {"email": self.user1.email},
+        )
+
+        kwargs = cognito.forgot_password.call_args.kwargs
+        self.assertNotIn("SecretHash", kwargs)
+
+    @patch("tcf_website.views.auth.boto3.client")
+    def test_user_not_found_in_cognito_maps_to_no_account(self, mock_client):
+        """A local account missing from Cognito is treated as no account."""
+        cognito = MagicMock()
+        cognito.forgot_password.side_effect = ClientError(
+            {"Error": {"Code": "UserNotFoundException", "Message": "not found"}},
+            "ForgotPassword",
+        )
+        mock_client.return_value = cognito
+
+        response = self.client.post(
+            reverse("forgot_password"),
+            {"email": self.user1.email},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(NO_ACCOUNT_MESSAGE, _messages(response))
+
+    @patch("tcf_website.views.auth.boto3.client")
+    def test_generic_cognito_error_shows_retry_message(self, mock_client):
+        """Any other Cognito error yields a generic retry message, not a crash."""
+        cognito = MagicMock()
+        cognito.forgot_password.side_effect = ClientError(
+            {"Error": {"Code": "TooManyRequestsException", "Message": "slow down"}},
+            "ForgotPassword",
+        )
+        mock_client.return_value = cognito
+
+        response = self.client.post(
+            reverse("forgot_password"),
+            {"email": self.user1.email},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        msgs = _messages(response)
+        self.assertTrue(any("try again" in m.lower() for m in msgs), msgs)
+        # The generic error must not leak whether the account exists.
+        self.assertNotIn(NO_ACCOUNT_MESSAGE, msgs)

--- a/tcf_website/urls.py
+++ b/tcf_website/urls.py
@@ -112,4 +112,9 @@ urlpatterns = [
     path("login/", views.auth.login, name="login"),
     path("cognito-callback/", views.auth.cognito_callback, name="cognito_callback"),
     path("logout/", views.auth.logout, name="logout"),
+    path(
+        "forgot-password/",
+        views.auth.forgot_password,
+        name="forgot_password",
+    ),
 ]

--- a/tcf_website/views/__init__.py
+++ b/tcf_website/views/__init__.py
@@ -1,7 +1,7 @@
 """Application views."""
 
 from .account import DeleteProfile, profile, reviews
-from .auth import login, logout
+from .auth import forgot_password, login, logout
 from .catalog import browse, department, search
 from .clubs import club_category, club_view
 from .courses import course_instructor, course_view

--- a/tcf_website/views/auth/__init__.py
+++ b/tcf_website/views/auth/__init__.py
@@ -1,23 +1,35 @@
 """Auth related views."""
 
+import hashlib
+import hmac
 import json
 import logging
 import urllib.parse
 from base64 import b64encode
 
+import boto3
 import requests
+from botocore.exceptions import BotoCoreError, ClientError
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth import authenticate
+from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth import login as auth_login
 from django.contrib.auth import logout as auth_logout
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseRedirect
-from django.shortcuts import redirect
+from django.shortcuts import redirect, render
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_POST
 
 logger = logging.getLogger(__name__)
+
+# Shown when the submitted email has no local account. Deliberately identical
+# to the message rendered for Cognito's ``UserNotFoundException`` so the two
+# "no account" paths are indistinguishable to the user (see issue #1251).
+NO_ACCOUNT_MESSAGE = (
+    "No account is associated with that email address. "
+    "Sign in with your UVA email to create an account."
+)
 
 
 def login(request):
@@ -123,3 +135,93 @@ def logout(request):
     )
 
     return HttpResponseRedirect(cognito_logout_url)
+
+
+def _cognito_secret_hash(username):
+    """Return the Cognito ``SECRET_HASH`` for ``username``.
+
+    Required only when the app client is configured with a client secret.
+    It is the base64-encoded HMAC-SHA256 of ``username + client_id`` keyed by
+    the client secret, per the AWS Cognito docs.
+    """
+    message = f"{username}{settings.COGNITO_APP_CLIENT_ID}".encode()
+    key = settings.COGNITO_APP_CLIENT_SECRET.encode()
+    digest = hmac.new(key, message, hashlib.sha256).digest()
+    return b64encode(digest).decode()
+
+
+def forgot_password(request):
+    """Custom password-reset entry point.
+
+    Cognito's hosted UI is configured with ``prevent_user_existence_errors``
+    enabled, so a reset request for an unknown email silently no-ops and the
+    user is left with no feedback (issue #1251). This view checks the local
+    account table first: if no account matches the submitted email, it tells
+    the user to sign in with their UVA email to create one; otherwise it asks
+    Cognito to send the reset code and redirects to login.
+    """
+    if request.method != "POST":
+        return render(request, "site/auth/forgot_password.html")
+
+    email = request.POST.get("email", "").strip()
+
+    if not email:
+        messages.error(request, "Please enter your email address.")
+        return render(request, "site/auth/forgot_password.html")
+
+    user_model = get_user_model()
+    # Emails are stored from the Cognito ``email`` claim; match
+    # case-insensitively so casing differences don't hide an account.
+    account = user_model.objects.filter(email__iexact=email).first()
+
+    if account is None:
+        messages.error(request, NO_ACCOUNT_MESSAGE)
+        return render(request, "site/auth/forgot_password.html")
+
+    # Cognito usernames are the local part of the UVA email (see
+    # ``CognitoBackend.authenticate``), and the reset code is delivered to the
+    # address on file, so drive the Cognito call with the stored username.
+    username = account.username
+
+    try:
+        client = boto3.client(
+            "cognito-idp", region_name=settings.COGNITO_REGION_NAME
+        )
+        params = {
+            "ClientId": settings.COGNITO_APP_CLIENT_ID,
+            "Username": username,
+        }
+        if settings.COGNITO_APP_CLIENT_SECRET:
+            params["SecretHash"] = _cognito_secret_hash(username)
+
+        client.forgot_password(**params)
+    except ClientError as exc:
+        error_code = exc.response.get("Error", {}).get("Code", "")
+        if error_code == "UserNotFoundException":
+            # Local account exists but Cognito has no matching user. Treat it
+            # the same as "no account" rather than leaking the discrepancy.
+            messages.error(request, NO_ACCOUNT_MESSAGE)
+            return render(request, "site/auth/forgot_password.html")
+
+        logger.error("Cognito forgot_password failed: %s", exc)
+        messages.error(
+            request,
+            "We couldn't start a password reset right now. Please try again "
+            "later.",
+        )
+        return render(request, "site/auth/forgot_password.html")
+    except BotoCoreError as exc:
+        logger.exception("Cognito forgot_password client error: %s", exc)
+        messages.error(
+            request,
+            "We couldn't start a password reset right now. Please try again "
+            "later.",
+        )
+        return render(request, "site/auth/forgot_password.html")
+
+    messages.success(
+        request,
+        "If an account exists for that email, we've sent a password reset "
+        "link. Check your inbox.",
+    )
+    return redirect("login")

--- a/tcf_website/views/auth/__init__.py
+++ b/tcf_website/views/auth/__init__.py
@@ -184,9 +184,7 @@ def forgot_password(request):
     username = account.username
 
     try:
-        client = boto3.client(
-            "cognito-idp", region_name=settings.COGNITO_REGION_NAME
-        )
+        client = boto3.client("cognito-idp", region_name=settings.COGNITO_REGION_NAME)
         params = {
             "ClientId": settings.COGNITO_APP_CLIENT_ID,
             "Username": username,
@@ -206,16 +204,14 @@ def forgot_password(request):
         logger.error("Cognito forgot_password failed: %s", exc)
         messages.error(
             request,
-            "We couldn't start a password reset right now. Please try again "
-            "later.",
+            "We couldn't start a password reset right now. Please try again later.",
         )
         return render(request, "site/auth/forgot_password.html")
     except BotoCoreError as exc:
         logger.exception("Cognito forgot_password client error: %s", exc)
         messages.error(
             request,
-            "We couldn't start a password reset right now. Please try again "
-            "later.",
+            "We couldn't start a password reset right now. Please try again later.",
         )
         return render(request, "site/auth/forgot_password.html")
 


### PR DESCRIPTION
Closes #1251

## ⚠️ Draft for maintainer discussion — security tradeoff
Explicitly telling a user "no account exists" partially defeats Cognito's `prevent_user_existence_errors = "ENABLED"` (`iac/cognito.tf:66`) anti-enumeration protection — it lets an attacker probe which emails have accounts. **The issue explicitly requests this behavior**, and a prior attempt ([PR #1254](https://github.com/thecourseforum/theCourseForum2/pull/1254)) was closed over exactly this tension. Opening as **draft** so maintainers can decide whether the UX win is worth the enumeration exposure.

## Problem
Auth is fully Cognito-hosted. When someone requests a password reset (or email OTP) for an email with no account, Cognito silently no-ops — no email, no message — leaving the user confused.

## Fix
New custom `/forgot-password/` Django flow:
1. User enters email; the view looks it up in the local auth-user table **case-insensitively** (`email__iexact`).
2. No match → *"No account is associated with that email address. Sign in with your UVA email to create an account."*
3. Match → calls Cognito `forgot_password` via boto3 (computes `SECRET_HASH` when the app client has a secret) to send the reset email; redirects to login with a generic confirmation.
4. `UserNotFoundException` → same no-account message; other Cognito errors → generic retry (no existence leak) + logged.

Adds a "Forgot your password?" link to the login modal.

**Leakage limiting:** the success copy is deliberately generic ("If an account exists…") and Cognito-side errors never reveal existence — the only disclosure is the local-DB pre-check the issue asks for.

## Verification (actually run — throwaway Postgres)
- `manage.py check` — no issues.
- New `tcf_website/tests/test_auth.py` — **8/8 pass** (GET render, empty/unknown/known email, case-insensitivity, secret-hash on/off, `UserNotFoundException`, generic error).
- Existing `test_redirects` (33 incl. auth) — pass. `ruff check` — clean.

## Follow-up
Rate-limit `/forgot-password/` (per-IP + per-email) — it's unauthenticated and triggers Cognito calls/emails.

---
🤖 Implemented with Claude Code.
