### PR TITLE
Warn at submit if a review may be hidden for toxicity (#1110)

### DIFF
--- a/tcf_website/review/services.py
+++ b/tcf_website/review/services.py
@@ -1,7 +1,22 @@
 """Review-related queries and small pure helpers."""
 
+from django.conf import settings
+
 from ..models import Instructor
 from ..utils import recent_semesters
+
+# Toxicity categories mirror the (removed) evaluate_review_toxicity batch command
+# and the display filters that hide reviews with toxicity_rating >= TOXICITY_THRESHOLD.
+_TOXICITY_CATEGORIES = [
+    "obscene",
+    "threat",
+    "insult",
+    "identity_attack",
+]
+
+# Cache the Detoxify model so we only pay initialization cost once per process.
+_detoxify_model = None
+_detoxify_unavailable = False
 
 
 def recent_semester_id_set() -> set[int]:
@@ -40,3 +55,70 @@ def is_duplicate_review_for_user(user, instance) -> bool:
             course=instance.course, instructor=instance.instructor
         ).exists()
     )
+
+
+def _get_detoxify_model():
+    """Lazily load and cache the Detoxify model.
+
+    Returns None when detoxify is not installed. Detoxify is an optional,
+    heavyweight dependency (see requirements history); it is deliberately not a
+    hard dependency of the web app. When absent we simply cannot score text
+    synchronously, and callers must treat the review as not-flagged so
+    submission is never blocked.
+    """
+    global _detoxify_model, _detoxify_unavailable
+    if _detoxify_model is not None:
+        return _detoxify_model
+    if _detoxify_unavailable:
+        return None
+    try:
+        from detoxify import Detoxify  # pylint: disable=import-outside-toplevel
+
+        _detoxify_model = Detoxify("original")
+    except Exception:  # pylint: disable=broad-except
+        # ImportError if not installed, or any model-init/runtime error.
+        _detoxify_unavailable = True
+        return None
+    return _detoxify_model
+
+
+def score_review_toxicity(text: str):
+    """Score review text and return (rating, category).
+
+    ``rating`` is on the same 0-100 scale used by ``toxicity_rating`` and the
+    ``TOXICITY_THRESHOLD`` display filter (rating = round(100 * toxicity)).
+    ``category`` is the most relevant toxicity label, or "" when there is no
+    text or scoring is unavailable. Mirrors the removed evaluate_review_toxicity
+    batch command so the pre-submission warning matches display filtering.
+
+    Returns ``(0, "")`` when there is no text or Detoxify is unavailable, so the
+    caller treats the review as not-flagged and never blocks submission.
+    """
+    if not text or not text.strip():
+        return 0, ""
+
+    model = _get_detoxify_model()
+    if model is None:
+        return 0, ""
+
+    try:
+        prediction = model.predict(text)
+    except Exception:  # pylint: disable=broad-except
+        return 0, ""
+
+    rating = round(100 * prediction["toxicity"])
+    category = max(
+        _TOXICITY_CATEGORIES,
+        key=lambda label: prediction.get(label, 0),
+    )
+    return rating, category
+
+
+def review_will_be_hidden_for_toxicity(text: str) -> bool:
+    """True if a review with this text would be hidden by the toxicity filter.
+
+    Matches the display filter used everywhere reviews are shown:
+    ``toxicity_rating >= settings.TOXICITY_THRESHOLD`` are hidden.
+    """
+    rating, _ = score_review_toxicity(text)
+    return rating >= settings.TOXICITY_THRESHOLD

--- a/tcf_website/review/services.py
+++ b/tcf_website/review/services.py
@@ -72,9 +72,12 @@ def _get_detoxify_model():
     if _detoxify_unavailable:
         return None
     try:
-        from detoxify import Detoxify  # pylint: disable=import-outside-toplevel
+        import importlib  # pylint: disable=import-outside-toplevel
 
-        _detoxify_model = Detoxify("original")
+        # Dynamic import: detoxify is an optional dependency that is intentionally
+        # not installed, so import it via importlib to avoid a hard static import.
+        detoxify = importlib.import_module("detoxify")
+        _detoxify_model = detoxify.Detoxify("original")
     except Exception:  # pylint: disable=broad-except
         # ImportError if not installed, or any model-init/runtime error.
         _detoxify_unavailable = True

--- a/tcf_website/templates/site/review/review.html
+++ b/tcf_website/templates/site/review/review.html
@@ -168,12 +168,49 @@
             </div>
         </form>
     </div>
+    {# Toxicity warning modal: submission is still allowed, review may just be hidden. #}
+    <div class="modal-backdrop"
+         id="toxicityWarningBackdrop"
+         data-modal-close
+         aria-label="Close"></div>
+    <div class="modal"
+         id="toxicityWarning"
+         role="dialog"
+         aria-labelledby="toxicityWarningTitle"
+         aria-modal="true">
+        <div class="modal__dialog modal__dialog--sm">
+            <div class="modal__header">
+                <h2 class="modal__title" id="toxicityWarningTitle">Review may be hidden</h2>
+                <button class="modal__close" data-modal-close aria-label="Close">
+                    <svg viewBox="0 0 24 24"
+                         fill="none"
+                         stroke="currentColor"
+                         stroke-width="2">
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
+                    </svg>
+                </button>
+            </div>
+            <div class="modal__body">
+                <p>
+                    This review may be hidden because it was flagged as potentially
+                    toxic. It will still be saved if you submit. Would you like to
+                    submit anyway or keep editing?
+                </p>
+            </div>
+            <div class="modal__footer">
+                <button type="button" class="btn btn--secondary" id="toxicityContinueBtn">Continue editing</button>
+                <button type="button" class="btn btn--primary" id="toxicitySubmitAnywayBtn">Submit anyway</button>
+            </div>
+        </div>
+    </div>
 {% endblock content %}
 {% block scripts %}
     <script src="{% static 'js/site/review/review_cascade.js' %}"></script>
     <script>
   const duplicateCheckUrl = "{% url 'check_review_duplicate' %}";
   const zeroHoursCheckUrl = "{% url 'check_zero_hours_per_week' %}";
+  const toxicityCheckUrl = "{% url 'check_review_toxicity' %}";
 
   const textarea = document.getElementById('reviewtext');
   const countDisplay = document.getElementById('word-count');
@@ -193,6 +230,39 @@
   }
 
   let zeroHoursWarned = false;
+
+  // Toxicity warning modal: resolves true to submit anyway, false to keep editing.
+  function confirmToxicitySubmit() {
+    return new Promise((resolve) => {
+      const submitAnyway = document.getElementById('toxicitySubmitAnywayBtn');
+      const continueEditing = document.getElementById('toxicityContinueBtn');
+      const backdrop = document.getElementById('toxicityWarningBackdrop');
+      const closeBtns = document.querySelectorAll('#toxicityWarning [data-modal-close]');
+
+      function cleanup(result) {
+        submitAnyway.removeEventListener('click', onSubmit);
+        continueEditing.removeEventListener('click', onCancel);
+        closeBtns.forEach((btn) => btn.removeEventListener('click', onCancel));
+        if (backdrop) backdrop.removeEventListener('click', onCancel);
+        if (window.modal) window.modal.close();
+        resolve(result);
+      }
+      function onSubmit() { cleanup(true); }
+      function onCancel() { cleanup(false); }
+
+      submitAnyway.addEventListener('click', onSubmit);
+      continueEditing.addEventListener('click', onCancel);
+      closeBtns.forEach((btn) => btn.addEventListener('click', onCancel));
+      if (backdrop) backdrop.addEventListener('click', onCancel);
+
+      if (window.modal) {
+        window.modal.open('toxicityWarning');
+      } else {
+        // Fallback if the modal library is unavailable.
+        resolve(confirm('This review may be hidden because it was flagged as potentially toxic. Submit anyway?'));
+      }
+    });
+  }
 
   document.getElementById('reviewForm').addEventListener('submit', async function(e) {
     e.preventDefault();
@@ -260,6 +330,44 @@
         const confirmZero = confirm('You entered 0 total hours per week. Is this correct?');
         if (confirmZero) {
           zeroHoursWarned = true;
+          await submitAfterToxicityCheck();
+        } else {
+          resetSubmitBtn();
+        }
+      } else {
+        await submitAfterToxicityCheck();
+      }
+    } catch (err) {
+      console.error(err);
+      alert('An error occurred. Please try again.');
+      resetSubmitBtn();
+    }
+
+    // Toxicity is a *display* concern: warn if the review may be hidden, but
+    // never block submission. "Submit anyway" still saves the review.
+    async function submitAfterToxicityCheck() {
+      let toxData;
+      try {
+        const toxRes = await fetch(toxicityCheckUrl, {
+          method: 'POST',
+          body: formData,
+          headers: xhrHeaders,
+        });
+        toxData = await toxRes.json();
+        if (!toxRes.ok) {
+          // Don't block submission on a moderation-check failure.
+          form.submit();
+          return;
+        }
+      } catch {
+        // Scoring unavailable or errored: proceed with submission.
+        form.submit();
+        return;
+      }
+
+      if (toxData.toxic) {
+        const proceed = await confirmToxicitySubmit();
+        if (proceed) {
           form.submit();
         } else {
           resetSubmitBtn();
@@ -267,10 +375,6 @@
       } else {
         form.submit();
       }
-    } catch (err) {
-      console.error(err);
-      alert('An error occurred. Please try again.');
-      resetSubmitBtn();
     }
   });
     </script>

--- a/tcf_website/tests/test_review.py
+++ b/tcf_website/tests/test_review.py
@@ -1,6 +1,7 @@
 """Tests for Review model."""
 
 import json
+from unittest import mock
 
 from django.contrib.messages import get_messages
 from django.db import IntegrityError
@@ -9,6 +10,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from ..models import Review, Vote
+from ..review import services
 from ..review.forms import ReviewForm
 from .test_utils import setup, suppress_request_warnings
 
@@ -262,3 +264,90 @@ class ReviewPreflightJsonTests(TestCase):
         self.assertEqual(response.status_code, 400)
         data = json.loads(response.content)
         self.assertFalse(data.get("ok", True))
+
+    def test_check_toxicity_xhr_invalid_returns_json_400(self):
+        """Invalid XHR to toxicity check returns JSON 400 (never redirects HTML)."""
+        self.client.force_login(self.user1)
+        response = self.client.post(
+            reverse("check_review_toxicity"),
+            {"text": "ab"},
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.content)
+        self.assertFalse(data.get("ok", True))
+        self.assertIn("error", data)
+
+    def test_check_toxicity_valid_returns_toxic_flag(self):
+        """Valid POST returns a boolean toxic flag; default (no scorer) is False."""
+        self.client.force_login(self.user1)
+        response = self.client.post(
+            reverse("check_review_toxicity"),
+            _review_post_data(self.course, self.instructor, self.semester),
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertIn("toxic", data)
+        # Detoxify is not installed in CI, so scoring is unavailable -> not flagged.
+        self.assertFalse(data["toxic"])
+
+    @mock.patch("tcf_website.review.services._get_detoxify_model")
+    def test_check_toxicity_flags_high_score(self, mock_model):
+        """When the scorer rates above threshold, the endpoint reports toxic."""
+        mock_model.return_value = _FakeDetoxify(toxicity=0.95)
+        self.client.force_login(self.user1)
+        response = self.client.post(
+            reverse("check_review_toxicity"),
+            _review_post_data(self.course, self.instructor, self.semester),
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(json.loads(response.content)["toxic"])
+
+
+class _FakeDetoxify:
+    """Stand-in for a Detoxify model returning a fixed toxicity prediction."""
+
+    def __init__(self, toxicity):
+        self._toxicity = toxicity
+
+    def predict(self, _text):
+        return {
+            "toxicity": self._toxicity,
+            "obscene": self._toxicity,
+            "threat": 0.0,
+            "insult": 0.1,
+            "identity_attack": 0.0,
+        }
+
+
+class ReviewToxicityScoringTests(TestCase):
+    """Unit tests for the toxicity scoring service and threshold logic."""
+
+    def test_empty_text_is_not_scored(self):
+        """Blank text short-circuits to (0, '') without needing a model."""
+        self.assertEqual(services.score_review_toxicity(""), (0, ""))
+        self.assertEqual(services.score_review_toxicity("   "), (0, ""))
+
+    @mock.patch("tcf_website.review.services._get_detoxify_model")
+    def test_scoring_scales_to_0_100_and_picks_category(self, mock_model):
+        """Rating is round(100 * toxicity) and category is the max label."""
+        mock_model.return_value = _FakeDetoxify(toxicity=0.9)
+        rating, category = services.score_review_toxicity("some text")
+        self.assertEqual(rating, 90)
+        self.assertEqual(category, "obscene")
+
+    @mock.patch("tcf_website.review.services._get_detoxify_model")
+    def test_will_be_hidden_matches_threshold(self, mock_model):
+        """Hidden iff rating >= TOXICITY_THRESHOLD, matching display filters."""
+        mock_model.return_value = _FakeDetoxify(toxicity=0.74)
+        self.assertTrue(services.review_will_be_hidden_for_toxicity("t"))
+        mock_model.return_value = _FakeDetoxify(toxicity=0.5)
+        self.assertFalse(services.review_will_be_hidden_for_toxicity("t"))
+
+    @mock.patch("tcf_website.review.services._get_detoxify_model", return_value=None)
+    def test_unavailable_scorer_never_flags(self, _mock_model):
+        """When Detoxify is unavailable, reviews are never treated as toxic."""
+        self.assertEqual(services.score_review_toxicity("anything"), (0, ""))
+        self.assertFalse(services.review_will_be_hidden_for_toxicity("anything"))

--- a/tcf_website/urls.py
+++ b/tcf_website/urls.py
@@ -67,6 +67,11 @@ urlpatterns = [
         name="check_zero_hours_per_week",
     ),
     path(
+        "reviews/check_toxicity/",
+        views.review.check_toxicity,
+        name="check_review_toxicity",
+    ),
+    path(
         "reviews/semesters-for-course/",
         views.review.review_semester_options,
         name="review_semester_options",

--- a/tcf_website/views/review/__init__.py
+++ b/tcf_website/views/review/__init__.py
@@ -5,6 +5,7 @@ from .delete_view import DeleteReview
 from .new_review import new_review
 from .preflight import (
     check_duplicate,
+    check_toxicity,
     check_zero_hours_per_week,
     review_instructor_options,
     review_semester_options,
@@ -15,6 +16,7 @@ __all__ = [
     "DeleteReview",
     "ReviewForm",
     "check_duplicate",
+    "check_toxicity",
     "check_zero_hours_per_week",
     "downvote",
     "new_review",

--- a/tcf_website/views/review/preflight.py
+++ b/tcf_website/views/review/preflight.py
@@ -11,6 +11,7 @@ from ...review.services import (
     instructors_for_course_semester,
     is_duplicate_review_for_user,
     recent_semester_id_set,
+    review_will_be_hidden_for_toxicity,
 )
 from ...utils import semesters_for_course
 
@@ -54,6 +55,23 @@ def check_zero_hours_per_week(request):
         if instance.hours_per_week == 0:
             return JsonResponse({"zero": True})
         return JsonResponse({"zero": False})
+    return _review_preflight_invalid_form_response(request, form)
+
+
+@login_required
+@require_POST
+def check_toxicity(request):
+    """Warn if a review would be hidden by the toxicity display filter.
+
+    This is a *display* concern, not a validation error: the review is still
+    saved on submit, but may be hidden from listings. So we never block
+    submission here -- we only signal so the frontend can warn the user.
+    """
+    form = ReviewForm(request.POST)
+    if form.is_valid():
+        instance = form.save(commit=False)
+        hidden = review_will_be_hidden_for_toxicity(instance.text)
+        return JsonResponse({"toxic": hidden})
     return _review_preflight_invalid_form_response(request, form)
 
 


### PR DESCRIPTION
Closes #1110

## Problem
There was no pre-submission feedback when a review would be hidden by the toxicity display filter — users had no idea their review wouldn't show up.

## Fix
Adds a pre-submit toxicity check mirroring the existing preflight/modal pattern (duplicate-review, zero-hours):
- New `check_toxicity` XHR endpoint (`reviews/check_toxicity/`) returning `{"toxic": bool}`.
- Scoring reuses the exact logic of the former `evaluate_review_toxicity` command + the shared `settings.TOXICITY_THRESHOLD` (74), so the warning matches what actually gets hidden.
- A "Review may be hidden / Submit anyway / Continue editing" modal wired into the existing submit handler.
- **Display concern only** — "Submit anyway" still saves the review; submission is never blocked (per the issue).

## ⚠️ Important caveat — the scorer is currently absent
`detoxify` was removed from the project entirely (commit `32623d53`, "remove detoxify ENTIRELY"); `toxicity_rating` is now populated out-of-band. The new service **lazily imports `detoxify` and fails open** (returns not-toxic) when it's unavailable — so with the current dependencies the modal never triggers and submission is never blocked. Re-adding `detoxify` to dependencies (local model, no API key, but heavyweight) activates the warning automatically. **This PR wires the mechanism; enabling it is a deploy decision.**

## Verification (run in the docker stack)
- `manage.py test tcf_website.tests.test_review` — **28 pass** (incl. 7 new).
- `manage.py check` clean; ruff + djlint clean.

## Follow-ups
- Re-add `detoxify` (or another local scorer) to make the warning live.
- The pre-existing `duplicate-warning` modal markup is dead (`alert()`-based) — left untouched; could be cleaned up separately.

---
🤖 Implemented with Claude Code.
