### PR TITLE
feat: explicit TCF_ENV runtime mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 env:
   PYTHON_TARGET: "3.12"
   DJANGO_SETTINGS_MODULE: tcf_core.settings.dev
+  TCF_ENV: ci
   SECRET_KEY: ci-secret-key-not-for-production
   # CI database (GitHub Actions postgres service)
   DB_NAME: tcf_db
@@ -80,7 +81,7 @@ jobs:
       code-coverage: ${{ steps.coverage.outputs.percentage }}
     services:
       postgres:
-        image: postgres:15.4
+        image: postgres:18.1
         env:
           POSTGRES_USER: ${{ env.DB_USER }}
           POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -17,6 +17,16 @@ cd theCourseForum2
 cp .env.example .env
 ```
 
+### Environment modes
+
+The `TCF_ENV` variable identifies the runtime mode:
+
+- `local` (the default): local development settings and debug tools
+- `ci`: CI settings with debug disabled
+- `prod`: production settings; ECS task definitions must set `TCF_ENV=prod`
+
+Invalid values cause Django to fail during startup.
+
 3. Build the project
 
 ```bash
@@ -69,16 +79,18 @@ docker exec -it tcf_django /bin/bash
 ## CI checks locally
 
 ```bash
-ruff check .
-ruff format --check .
-djlint tcf_website/templates --check --lint
-ty check
+uv run ruff check .
+uv run ruff format --check .
+uv run djlint tcf_website/templates --check --lint
+uv run ty check
 npm ci && npx eslint -c .config/.eslintrc.yml tcf_website/static/
-python manage.py migrate
-coverage run manage.py test
+uv run python manage.py migrate
+uv run coverage run manage.py test
 ```
 
-GitHub Actions sets `GITHUB_ACTIONS=true` so the same module runs with `DEBUG=False` and without the debug toolbar; see [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
+GitHub Actions sets `TCF_ENV=ci`, so the same settings module runs with
+`DEBUG=False` and without the debug toolbar; see
+[`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
 
 ## Authentication Functionality
 

--- a/iac/ecs.tf
+++ b/iac/ecs.tf
@@ -37,6 +37,10 @@ container_definitions = jsonencode([
           value = "tcf_core.settings.prod"
         },
         {
+          name  = "TCF_ENV"
+          value = "prod"
+        },
+        {
           name  = "AWS_STORAGE_BUCKET_NAME"
           value = aws_s3_bucket.static.id
         },

--- a/tcf_core/settings/base.py
+++ b/tcf_core/settings/base.py
@@ -4,18 +4,23 @@ import os
 
 import environ
 from django.contrib.messages import constants as messages
+from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse_lazy
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Django-environ library imports .env settings
-env = environ.Env(
-    # set casting, default value
-    DEBUG=(bool, False),
-)
+env = environ.Env()
 env_file = os.path.join(BASE_DIR, ".env")
 environ.Env.read_env(env_file)
+
+# Runtime mode, set by the launcher: local (default) | ci | prod.
+ENVIRONMENT = env.str("TCF_ENV", default="local")
+if ENVIRONMENT not in ("local", "ci", "prod"):
+    raise ImproperlyConfigured(
+        f"TCF_ENV must be one of 'local', 'ci', 'prod'; got {ENVIRONMENT!r}"
+    )
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env.str("SECRET_KEY")

--- a/tcf_core/settings/dev.py
+++ b/tcf_core/settings/dev.py
@@ -1,11 +1,8 @@
-"""Django settings for local development and CI.
+"""Django settings for local development and CI."""
 
-GitHub Actions sets GITHUB_ACTIONS=true on the runner; local shells do not.
-"""
+import importlib.util
 
 from .base import *
-
-_ci = os.environ.get("GITHUB_ACTIONS") == "true"
 
 DATABASES = {
     "default": {
@@ -23,13 +20,74 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static")
 ALLOWED_HOSTS = ["localhost", "127.0.0.1", ".grok.io", ".lhr.life"]
 
 
-DEBUG = not _ci
+DEBUG = ENVIRONMENT == "local"
 
-# Cachalot uses LocMemCache in dev (no Redis), which is per-process — management
-# commands invalidate a different cache instance than the web server sees.
-CACHALOT_ENABLED = False
+# Redis-backed cache/sessions like prod when REDIS_URL is set; without a
+# shared cache Cachalot invalidations can't reach other processes, so it stays
+# off and sessions fall back to plain db.
+redis_url = env.str("REDIS_URL", default="")
 
-if not _ci:
+if redis_url:
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.redis.RedisCache",
+            "LOCATION": redis_url,
+            "KEY_PREFIX": "tcf:dev",
+            "OPTIONS": {
+                "socket_connect_timeout": 5,
+                "socket_timeout": 5,
+                "retry_on_timeout": True,
+            },
+        }
+    }
+    SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+    SESSION_CACHE_ALIAS = "default"
+    CACHALOT_ENABLED = True
+else:
+    CACHALOT_ENABLED = False
+
+# Media via MinIO (S3 backend) when MINIO_ENDPOINT is set; static stays local.
+minio_endpoint = env.str("MINIO_ENDPOINT", default="")
+if minio_endpoint:
+    STORAGES = {
+        "default": {
+            "BACKEND": "storages.backends.s3.S3Storage",
+            "OPTIONS": {
+                "bucket_name": env.str("MINIO_BUCKET", default="tcf-media"),
+                "endpoint_url": minio_endpoint,
+                "access_key": env.str("MINIO_ACCESS_KEY", default="minioadmin"),
+                "secret_key": env.str("MINIO_SECRET_KEY", default="minioadmin"),
+                "addressing_style": "path",
+                "file_overwrite": False,
+            },
+        },
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
+    }
+
+    # Prod-style manifest statics, opt-in: needs collectstatic re-runs after
+    # static changes, and DEBUG=False (Django skips hashing in debug).
+    if env.bool("STATIC_S3", default=False):
+        DEBUG = False
+        STORAGES["staticfiles"] = {
+            "BACKEND": "storages.backends.s3.S3ManifestStaticStorage",
+            "OPTIONS": {
+                "bucket_name": env.str("STATIC_BUCKET", default="tcf-static"),
+                "endpoint_url": minio_endpoint,
+                "access_key": env.str("MINIO_ACCESS_KEY", default="minioadmin"),
+                "secret_key": env.str("MINIO_SECRET_KEY", default="minioadmin"),
+                "addressing_style": "path",
+                "custom_domain": env.str(
+                    "STATIC_CUSTOM_DOMAIN", default="localhost:8081"
+                ),
+                # storages joins as f"{url_protocol}//{domain}" — colon included.
+                "url_protocol": "http:",
+            },
+        }
+
+# Toolbar only in local mode when the package is installed.
+if ENVIRONMENT == "local" and importlib.util.find_spec("debug_toolbar") is not None:
     INSTALLED_APPS = INSTALLED_APPS + ["debug_toolbar"]
     MIDDLEWARE = (
         MIDDLEWARE[:2]

--- a/tcf_core/settings/prod.py
+++ b/tcf_core/settings/prod.py
@@ -1,6 +1,14 @@
 """Django settings for AWS production."""
 
+from django.core.exceptions import ImproperlyConfigured
+
 from .base import *
+
+# ECS sets TCF_ENV=prod (iac/ecs.tf); refuse to boot in any other mode.
+if ENVIRONMENT != "prod":
+    raise ImproperlyConfigured(
+        f"tcf_core.settings.prod requires TCF_ENV=prod; got {ENVIRONMENT!r}"
+    )
 
 DEBUG = False
 


### PR DESCRIPTION
Introduce a single explicit environment variable (TCF_ENV=local|ci|prod)
that declares which mode the process runs in, replacing inference from
side effects like GITHUB_ACTIONS or whether debug_toolbar happens to be
installed.

- base.py: parses and validates TCF_ENV at boot; bad values refuse to start
- dev.py: DEBUG and debug toolbar keyed off ENVIRONMENT == "local";
  opt-in prod-parity backends behind REDIS_URL / MINIO_ENDPOINT /
  STATIC_S3 (all default off, so behavior is unchanged unless enabled)
- prod.py: refuses to boot unless TCF_ENV=prod
- ci.yml sets TCF_ENV=ci; iac/ecs.tf sets TCF_ENV=prod


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment-specific configuration for local, CI, and production deployments.
  * Enabled optional Redis-backed caching and database sessions when configured.
  * Added optional MinIO media storage and manifest-based static file storage.
  * Debug tools are now available only in local development environments.

* **Bug Fixes**
  * Applications now fail clearly when an unsupported environment is configured or production settings are used incorrectly.

* **Documentation**
  * Documented supported environment modes and updated local CI setup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->