### PR TITLE
fix(course): sort instructors by semester

### DIFF
--- a/tcf_website/models/models.py
+++ b/tcf_website/models/models.py
@@ -804,24 +804,15 @@ class Course(models.Model):
                 - CATALOG_YEAR_WINDOW,
             }
 
-        latest_section_taught = Section.objects.filter(
-            course=self, instructors=OuterRef("pk")
-        ).order_by("-semester__number")
-
-        if latest_only:
-            semester_last_taught = Value(
-                latest_semester.pk, output_field=IntegerField()
+        semester_last_taught_number = (
+            Value(latest_semester.number, output_field=IntegerField())
+            if latest_only
+            else Subquery(
+                Section.objects.filter(course=self, instructors=OuterRef("pk"))
+                .order_by("-semester__number")
+                .values("semester__number")[:1]
             )
-            semester_last_taught_number = Value(
-                latest_semester.number, output_field=IntegerField()
-            )
-        else:
-            semester_last_taught = Subquery(
-                latest_section_taught.values("semester__id")[:1]
-            )
-            semester_last_taught_number = Subquery(
-                latest_section_taught.values("semester__number")[:1]
-            )
+        )
 
         return (
             Instructor.objects.filter(hidden=False, **base_filter)
@@ -846,7 +837,6 @@ class Course(models.Model):
                 ),
                 gpa=Avg("course_grades__average"),
                 difficulty=Avg("course_reviews__difficulty"),
-                semester_last_taught=semester_last_taught,
                 semester_last_taught_number=semester_last_taught_number,
             )
         )

--- a/tcf_website/models/models.py
+++ b/tcf_website/models/models.py
@@ -804,15 +804,24 @@ class Course(models.Model):
                 - CATALOG_YEAR_WINDOW,
             }
 
-        semester_last_taught = (
-            Value(latest_semester.pk, output_field=IntegerField())
-            if latest_only
-            else Subquery(
-                Section.objects.filter(course=self, instructors=OuterRef("pk"))
-                .order_by("-semester__number")
-                .values("semester__id")[:1]
+        latest_section_taught = Section.objects.filter(
+            course=self, instructors=OuterRef("pk")
+        ).order_by("-semester__number")
+
+        if latest_only:
+            semester_last_taught = Value(
+                latest_semester.pk, output_field=IntegerField()
             )
-        )
+            semester_last_taught_number = Value(
+                latest_semester.number, output_field=IntegerField()
+            )
+        else:
+            semester_last_taught = Subquery(
+                latest_section_taught.values("semester__id")[:1]
+            )
+            semester_last_taught_number = Subquery(
+                latest_section_taught.values("semester__number")[:1]
+            )
 
         return (
             Instructor.objects.filter(hidden=False, **base_filter)
@@ -838,6 +847,7 @@ class Course(models.Model):
                 gpa=Avg("course_grades__average"),
                 difficulty=Avg("course_reviews__difficulty"),
                 semester_last_taught=semester_last_taught,
+                semester_last_taught_number=semester_last_taught_number,
             )
         )
 
@@ -853,16 +863,16 @@ class Course(models.Model):
             "gpa": "gpa",
             "rating": "rating",
             "difficulty": "difficulty",
-            "last_taught": "semester_last_taught",
+            "last_taught": "semester_last_taught_number",
         }
-        sort_field = sort_field_map.get(sortby, "semester_last_taught")
+        sort_field = sort_field_map.get(sortby, "semester_last_taught_number")
         order_expr = (
             F(sort_field).desc(nulls_last=True)
             if order == "desc"
             else F(sort_field).asc(nulls_last=True)
         )
         return self.get_instructors_and_data(latest_semester, latest_only).order_by(
-            order_expr
+            order_expr, "last_name", "first_name"
         )
 
     @classmethod

--- a/tcf_website/tests/test_course.py
+++ b/tcf_website/tests/test_course.py
@@ -1,8 +1,9 @@
 """Tests for Course model."""
 
 from django.test import TestCase
+from django.utils import timezone
 
-from ..models import Semester
+from ..models import Instructor, Section, Semester
 from .test_utils import setup
 
 
@@ -64,3 +65,73 @@ class CourseTestCase(TestCase):
         # split across lines for readability (line length)
         # this link doesn't actually work because CS 420 is not a real class
         self.assertEqual(eval_link, self.course.eval_link())
+
+
+class CourseInstructorOrderTestCase(TestCase):
+    """Tests for how the course page orders instructors by semester last taught."""
+
+    def setUp(self):
+        setup(self)
+        year = timezone.now().year
+        self.fall = Semester.objects.get_or_create(
+            year=year, season="FALL", defaults={"number": int(f"1{year % 100}8")}
+        )[0]
+        self.summer = Semester.objects.get_or_create(
+            year=year, season="SUMMER", defaults={"number": int(f"1{year % 100}6")}
+        )[0]
+        self.assertLess(self.fall.pk, self.summer.pk)
+
+        self.fall_instructor = Instructor.objects.create(
+            first_name="Fall", last_name="Teacher"
+        )
+        self.summer_instructor = Instructor.objects.create(
+            first_name="Summer", last_name="Teacher"
+        )
+        for instructor, semester in (
+            (self.fall_instructor, self.fall),
+            (self.summer_instructor, self.summer),
+        ):
+            section = Section.objects.create(
+                course=self.course,
+                semester=semester,
+                sis_section_number=10000 + semester.number,
+            )
+            section.instructors.set([instructor])
+
+    def sorted_instructors(self, order):
+        """Instructors for the last-5-years view, sorted by semester last taught."""
+        return list(
+            self.course.sort_instructors_by_key(
+                Semester.latest(), False, order, "last_taught"
+            )
+        )
+
+    def test_recent_semester_sorts_first_regardless_of_load_order(self):
+        """Fall outranks Summer of the same year even though it was loaded first."""
+        instructors = self.sorted_instructors("desc")
+
+        self.assertEqual(
+            [self.fall_instructor.pk, self.summer_instructor.pk],
+            [i.pk for i in instructors[:2]],
+        )
+
+    def test_ascending_order_puts_oldest_semester_first(self):
+        """Ascending order is the exact reverse ranking by semester."""
+        instructors = self.sorted_instructors("asc")
+        order = [i.pk for i in instructors]
+
+        self.assertLess(
+            order.index(self.summer_instructor.pk),
+            order.index(self.fall_instructor.pk),
+        )
+
+    def test_semester_last_taught_is_the_semester_id(self):
+        """The course view resolves this annotation as a Semester primary key."""
+        instructors = {i.pk: i for i in self.sorted_instructors("desc")}
+
+        self.assertEqual(
+            self.fall.pk, instructors[self.fall_instructor.pk].semester_last_taught
+        )
+        self.assertEqual(
+            self.summer.pk, instructors[self.summer_instructor.pk].semester_last_taught
+        )

--- a/tcf_website/tests/test_course.py
+++ b/tcf_website/tests/test_course.py
@@ -1,6 +1,7 @@
 """Tests for Course model."""
 
 from django.test import TestCase
+from django.urls import reverse
 from django.utils import timezone
 
 from ..models import Instructor, Section, Semester
@@ -125,13 +126,29 @@ class CourseInstructorOrderTestCase(TestCase):
             order.index(self.fall_instructor.pk),
         )
 
-    def test_semester_last_taught_is_the_semester_id(self):
-        """The course view resolves this annotation as a Semester primary key."""
+    def test_semester_last_taught_number_is_the_sis_semester_code(self):
+        """The course view resolves this annotation back into a Semester."""
         instructors = {i.pk: i for i in self.sorted_instructors("desc")}
 
         self.assertEqual(
-            self.fall.pk, instructors[self.fall_instructor.pk].semester_last_taught
+            self.fall.number,
+            instructors[self.fall_instructor.pk].semester_last_taught_number,
         )
         self.assertEqual(
-            self.summer.pk, instructors[self.summer_instructor.pk].semester_last_taught
+            self.summer.number,
+            instructors[self.summer_instructor.pk].semester_last_taught_number,
         )
+
+    def test_course_page_labels_each_instructor_with_their_last_semester(self):
+        """The rendered page resolves semester numbers into display names."""
+        url = reverse("course", args=["CS", self.course.number])
+        response = self.client.get(url, {"latest": "false"})
+        rendered = response.content.decode()
+
+        self.assertEqual(200, response.status_code)
+        self.assertLess(
+            rendered.index(str(self.fall)),
+            rendered.index(str(self.summer)),
+            "Fall should be rendered above Summer",
+        )
+        self.assertNotIn("Unknown", rendered)

--- a/tcf_website/views/courses/course.py
+++ b/tcf_website/views/courses/course.py
@@ -80,10 +80,14 @@ def course_view(request, mnemonic: str, course_number: int):
         build_section_times_maps_by_instructor(course.id, latest_semester)
     )
 
-    sem_ids = {i.semester_last_taught for i in instructors if i.semester_last_taught}
-    sems = {s.pk: s for s in Semester.objects.filter(pk__in=sem_ids)}
+    sem_numbers = {
+        i.semester_last_taught_number
+        for i in instructors
+        if i.semester_last_taught_number
+    }
+    sems = {s.number: s for s in Semester.objects.filter(number__in=sem_numbers)}
     for instructor in instructors:
-        sem = sems.get(instructor.semester_last_taught)
+        sem = sems.get(instructor.semester_last_taught_number)
         instructor.semester_last_taught = str(sem) if sem else "Unknown"
         instructor.times = lecture_times_by_instructor.get(instructor.id, {})
         instructor.all_times = all_times_by_instructor.get(instructor.id, {})


### PR DESCRIPTION
## GitHub Issues addressed

- This PR closes #1278

## What I did

- Changed sorting on Last 5 Years page to be by semester_number (from SIS) instead of semester_id (auto-generated by postgres)
- Added a tiebreaker for instructors in same semester to first sort by instructor last name then first name instead of random postgres ordering

## Screenshots

- Before (APMA 3100)
<img width="698" height="450" alt="image" src="https://github.com/user-attachments/assets/c0189a8d-dff0-4528-9178-2b8531037e8c" />

- After
<img width="531" height="765" alt="image" src="https://github.com/user-attachments/assets/a5ccaa4e-6ce7-47cc-81e6-e61e1169432d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected instructor “last taught” semester sorting to use official semester numbers.
  - Ensured recent semesters sort correctly regardless of data load order.
  - Added consistent last-name and first-name tie-breaking for instructor lists.
  - Fixed course pages so each instructor displays their correct last-taught semester label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->