### PR TITLE
Make browse school accordions accessible to screen-readers

### DIFF
--- a/tcf_website/static/css/site/pages/browse.css
+++ b/tcf_website/static/css/site/pages/browse.css
@@ -105,11 +105,17 @@
   margin-bottom: var(--space-8);
 }
 
+.school-header__heading {
+  margin: 0;
+}
+
 .school-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-4);
+
+  width: 100%;
 
   padding: var(--space-3) var(--space-5);
 
@@ -118,6 +124,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-xl);
 
+  text-align: left;
   cursor: pointer;
   transition: border-color var(--duration-fast) var(--ease-default);
 }
@@ -136,6 +143,11 @@
   display: flex;
   align-items: center;
   gap: var(--space-4);
+}
+
+.school-header__text {
+  display: flex;
+  flex-direction: column;
 }
 
 .school-header__icon {

--- a/tcf_website/templates/site/catalog/browse.html
+++ b/tcf_website/templates/site/catalog/browse.html
@@ -95,11 +95,14 @@ document.addEventListener('DOMContentLoaded', function() {
   // School accordion toggle
   document.querySelectorAll('.school-header').forEach(header => {
     header.addEventListener('click', function() {
-      const section = this.parentElement;
+      const section = this.closest('.school-section');
       const grid = section.querySelector('.departments-grid');
+      const willExpand = this.getAttribute('aria-expanded') !== 'true';
 
-      this.classList.toggle('is-open');
-      grid.classList.toggle('is-open');
+      this.setAttribute('aria-expanded', String(willExpand));
+      this.classList.toggle('is-open', willExpand);
+      grid.classList.toggle('is-open', willExpand);
+      grid.hidden = !willExpand;
     });
   });
 });

--- a/tcf_website/templates/site/catalog/components/_school_section.html
+++ b/tcf_website/templates/site/catalog/components/_school_section.html
@@ -1,31 +1,40 @@
 {# School Section Component #}
 <div class="school-section">
-    <div class="school-header {% if expanded %}is-open{% endif %}"
-         id="school-{{ school.id }}">
-        <div class="school-header__info">
-            <div class="school-header__icon">
-                <svg viewBox="0 0 24 24"
-                     fill="none"
-                     stroke="currentColor"
-                     stroke-width="2">
-                    <path d="M22 10v6M2 10l10-5 10 5-10 5z"></path>
-                    <path d="M6 12v5c3 3 9 3 12 0v-5"></path>
-                </svg>
-            </div>
-            <div>
-                <h3 class="school-header__title">{{ school.name }}</h3>
-                <span class="school-header__count">{{ school.department_set.count }} department{{ school.department_set.count|pluralize }}</span>
-            </div>
-        </div>
-        <svg class="school-header__chevron"
-             viewBox="0 0 24 24"
-             fill="none"
-             stroke="currentColor"
-             stroke-width="2">
-            <polyline points="6 9 12 15 18 9"></polyline>
-        </svg>
-    </div>
-    <div class="departments-grid {% if expanded %}is-open{% endif %}">
+    <h3 class="school-header__heading">
+        <button class="school-header {% if expanded %}is-open{% endif %}"
+                id="school-{{ school.id }}-toggle"
+                type="button"
+                aria-expanded="{% if expanded %}true{% else %}false{% endif %}"
+                aria-controls="school-{{ school.id }}-departments">
+            <span class="school-header__info">
+                <span class="school-header__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24"
+                         fill="none"
+                         stroke="currentColor"
+                         stroke-width="2">
+                        <path d="M22 10v6M2 10l10-5 10 5-10 5z"></path>
+                        <path d="M6 12v5c3 3 9 3 12 0v-5"></path>
+                    </svg>
+                </span>
+                <span class="school-header__text">
+                    <span class="school-header__title">{{ school.name }}</span>
+                    <span class="school-header__count">{{ school.department_set.count }} department{{ school.department_set.count|pluralize }}</span>
+                </span>
+            </span>
+            <svg class="school-header__chevron"
+                 aria-hidden="true"
+                 viewBox="0 0 24 24"
+                 fill="none"
+                 stroke="currentColor"
+                 stroke-width="2">
+                <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+        </button>
+    </h3>
+    <div class="departments-grid {% if expanded %}is-open{% endif %}"
+         id="school-{{ school.id }}-departments"
+         aria-labelledby="school-{{ school.id }}-toggle"
+         {% if not expanded %}hidden{% endif %}>
         {% for dept in school.department_set.all|dictsort:"name" %}
             <a href="{% url 'department' dept_id=dept.pk %}" class="department-card">
                 <span class="department-card__name">{{ dept.name }}</span>

--- a/tcf_website/tests/test_browse.py
+++ b/tcf_website/tests/test_browse.py
@@ -41,6 +41,37 @@ class CourseViewTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context["has_search"])
 
+    def test_school_accordions_use_keyboard_accessible_buttons(self):
+        """School headings expose native keyboard controls and accordion state."""
+        clas = School.objects.create(name="College of Arts & Sciences")
+        School.objects.create(name="School of Engineering & Applied Science")
+
+        response = self.client.get(reverse("browse"))
+        html = response.content.decode()
+
+        self.assertRegex(
+            html,
+            rf'<h3 class="school-header__heading">\s*<button class="school-header '
+            rf'[^\"]*"\s+id="school-{clas.pk}-toggle"',
+        )
+        self.assertIn('type="button"', html)
+        self.assertIn('aria-expanded="false"', html)
+        self.assertIn(f'aria-controls="school-{clas.pk}-departments"', html)
+        self.assertIn(f'id="school-{clas.pk}-departments"', html)
+        self.assertIn(f'aria-labelledby="school-{clas.pk}-toggle"', html)
+        self.assertNotIn('<div class="school-header ', html)
+
+    def test_school_accordion_toggle_updates_accessibility_state(self):
+        """Accordion toggles keep ARIA and panel visibility in sync."""
+        School.objects.create(name="College of Arts & Sciences")
+        School.objects.create(name="School of Engineering & Applied Science")
+
+        response = self.client.get(reverse("browse"))
+        html = response.content.decode()
+
+        self.assertIn("this.setAttribute('aria-expanded', String(willExpand));", html)
+        self.assertIn("grid.hidden = !willExpand;", html)
+
     def test_browse_partial_results_returns_html(self):
         """XHR partial=results with search params returns results fragment."""
         response = self.client.get(


### PR DESCRIPTION
## What I did

- Replaced clickable school header `<div>` elements with semantic buttons inside level-three headings.
- Added and synchronized `aria-expanded`, `aria-controls`, and panel visibility.
- Preserved the existing layout and styling.
- Added accessibility regression tests.

## Testing

- Verified Tab, Enter, and Space keyboard behavior.
- Confirmed screen readers expose each accordion as an expanded or collapsed button.
- Ran Ruff, djLint, and `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved school section controls with native buttons and clearer expanded/collapsed state information for assistive technologies.
  * Added accessible relationships between school headers and their department lists.

* **User Experience**
  * School sections now open and close more reliably while keeping visual and accessibility states synchronized.
  * Improved school header layout with full-width, left-aligned content and vertically stacked text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->