### PR TITLE
feat(data): add school of data science to browse page

### DIFF
--- a/tcf_website/migrations/0029_school_of_data_science.py
+++ b/tcf_website/migrations/0029_school_of_data_science.py
@@ -1,0 +1,36 @@
+from django.db import migrations
+
+
+def add_school_of_data_science(apps, schema_editor):
+    alias = schema_editor.connection.alias
+    School = apps.get_model("tcf_website", "School")
+    Department = apps.get_model("tcf_website", "Department")
+    Subdepartment = apps.get_model("tcf_website", "Subdepartment")
+
+    school, _ = School.objects.using(alias).get_or_create(name="School of Data Science")
+    department, _ = Department.objects.using(alias).get_or_create(
+        name="Data Science", school=school
+    )
+    # DS is the school's subject in UVA's catalog. Preserve its primary key so
+    # existing courses, grades, and reviews keep their relationships.
+    subject, _ = Subdepartment.objects.using(alias).get_or_create(
+        mnemonic="DS", defaults={"name": "Data Science", "department": department}
+    )
+    subject.department = department
+    fields = ["department"]
+    if not subject.name:
+        subject.name = "Data Science"
+        fields.append("name")
+    subject.save(using=alias, update_fields=fields)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tcf_website", "0028_schedule_share_token_schedulebookmark_and_more"),
+    ]
+
+    # Retain repaired catalog data on rollback: deleting it would cascade to
+    # courses and reviews, and the subject's original parent is unknown.
+    operations = [
+        migrations.RunPython(add_school_of_data_science, migrations.RunPython.noop),
+    ]

--- a/tcf_website/tests/test_data_science_migration.py
+++ b/tcf_website/tests/test_data_science_migration.py
@@ -1,0 +1,56 @@
+"""Regression coverage for the Data Science catalog repair."""
+
+from importlib import import_module
+from types import SimpleNamespace
+
+from django.apps import apps
+from django.db import connection
+from django.test import TestCase
+from django.urls import reverse
+
+from tcf_website.models import Department, School, Subdepartment
+
+repair = import_module(
+    "tcf_website.migrations.0029_school_of_data_science"
+).add_school_of_data_science
+
+
+class DataScienceMigrationTests(TestCase):
+    def run_repair(self):
+        repair(apps, SimpleNamespace(connection=connection))
+
+    def test_creates_missing_hierarchy_and_browse_link(self):
+        School.objects.filter(name="School of Data Science").delete()
+        self.run_repair()
+        subject = Subdepartment.objects.get(mnemonic="DS")
+        self.assertEqual(subject.name, "Data Science")
+        self.assertEqual(subject.department.school.name, "School of Data Science")
+        School.objects.get_or_create(name="College of Arts & Sciences")
+        School.objects.get_or_create(name="School of Engineering & Applied Science")
+        response = self.client.get(reverse("browse"))
+        self.assertContains(response, "School of Data Science")
+        self.assertContains(
+            response, reverse("department", args=[subject.department_id])
+        )
+
+    def test_reparents_existing_subject_without_duplicates(self):
+        School.objects.filter(name="School of Data Science").delete()
+        school = School.objects.create(name="Miscellaneous")
+        department = Department.objects.create(name="Miscellaneous", school=school)
+        subject = Subdepartment.objects.create(
+            mnemonic="DS", name="Existing subject name", department=department
+        )
+        other = Subdepartment.objects.create(
+            mnemonic="DSTS", name="Unrelated subject", department=department
+        )
+        self.run_repair()
+        self.run_repair()
+        subject.refresh_from_db()
+        other.refresh_from_db()
+        self.assertEqual(subject.department.school.name, "School of Data Science")
+        self.assertEqual(subject.name, "Existing subject name")
+        self.assertEqual(Subdepartment.objects.get(mnemonic="DS").pk, subject.pk)
+        self.assertEqual(other.department_id, department.pk)
+        self.assertEqual(
+            Department.objects.filter(school=subject.department.school).count(), 1
+        )


### PR DESCRIPTION
Creates a data migration to add School of Data Science to the list of schools on the browse page.

No additional deployment steps are needed because `python manage.py migrate` already runs on every production deployment. 
