### PR TITLE
Stop treating "To be Announced" as a real instructor

### DIFF
--- a/tcf_website/management/commands/fetch_grades.py
+++ b/tcf_website/management/commands/fetch_grades.py
@@ -254,6 +254,15 @@ def clean_text(text):
     return re.sub(r"\s+", " ", text or "").strip()
 
 
+def is_tba_instructor(name):
+    """True when SIS/FOIA used a placeholder instead of a real instructor.
+
+    Recent term files use "To be Announced" (lowercase b); older files used
+    "To Be Announced". Compare case-insensitively so both are dropped.
+    """
+    return clean_text(name).casefold() == "to be announced"
+
+
 def format_sis_name(name):
     """Convert the semester file's "First Last" to "Last,First".
 
@@ -261,7 +270,7 @@ def format_sis_name(name):
     output keep matching the Instructor rows load_grades looks them up in.
     """
     name = clean_text(name)
-    if not name or name == "To Be Announced":
+    if not name or is_tba_instructor(name):
         return "..."
     parts = name.split(",")[0].strip().split()
     if len(parts) < 2:
@@ -277,7 +286,7 @@ def format_engine_name(name):
     marked "...", so anything not in that shape becomes "...".
     """
     name = clean_text(name)
-    if name.count(",") != 1 or name == "To Be Announced":
+    if name.count(",") != 1 or is_tba_instructor(name):
         return "..."
     return name
 

--- a/tcf_website/management/commands/load_semester.py
+++ b/tcf_website/management/commands/load_semester.py
@@ -251,7 +251,11 @@ class Command(BaseCommand):
                     fixed_instructor_names.append(stripped)
 
         for name in fixed_instructor_names:
-            if name in {"Staff", "Faculty Staff", "Faculty"} or name.isspace():
+            if (
+                name in {"Staff", "Faculty Staff", "Faculty"}
+                or name.isspace()
+                or name.casefold() == "to be announced"
+            ):
                 instructors.add(self.STAFF)
             else:
                 names = name.split()

--- a/tcf_website/tests/test_tba_instructor_names.py
+++ b/tcf_website/tests/test_tba_instructor_names.py
@@ -1,0 +1,29 @@
+"""Placeholder instructor names must be dropped regardless of casing."""
+
+from django.test import SimpleTestCase
+
+from tcf_website.management.commands.fetch_grades import (
+    format_engine_name,
+    format_sis_name,
+    is_tba_instructor,
+)
+
+
+class TBAInstructorNameTestCase(SimpleTestCase):
+    def test_is_tba_instructor_case_variants(self):
+        self.assertTrue(is_tba_instructor("To Be Announced"))
+        self.assertTrue(is_tba_instructor("To be Announced"))
+        self.assertTrue(is_tba_instructor("to be announced"))
+        self.assertTrue(is_tba_instructor("  To be Announced  "))
+        self.assertFalse(is_tba_instructor("Jane Doe"))
+        self.assertFalse(is_tba_instructor(""))
+
+    def test_format_sis_name_drops_tba(self):
+        self.assertEqual(format_sis_name("To Be Announced"), "...")
+        self.assertEqual(format_sis_name("To be Announced"), "...")
+        self.assertEqual(format_sis_name("Jane Doe"), "Doe,Jane")
+
+    def test_format_engine_name_drops_tba(self):
+        self.assertEqual(format_engine_name("To Be Announced"), "...")
+        self.assertEqual(format_engine_name("To be Announced"), "...")
+        self.assertEqual(format_engine_name("Doe,Jane"), "Doe,Jane")


### PR DESCRIPTION
## Summary
SIS/Lou's List data now uses `To be Announced` (lowercase *b*) as the placeholder instructor name. The existing filter only dropped the older spelling `To Be Announced`, so those rows were stored and shown as a real instructor (`To Announced`).

## Motivation
Fixes #1290.

## Implementation
- Add `is_tba_instructor()` in `fetch_grades.py` and use it from `format_sis_name` / `format_engine_name` so both casings become the `...` placeholder.
- Treat the same placeholder as Staff in `load_semester.load_instructors` so semester imports do not create a fake instructor row.

## Testing
- Added `tcf_website/tests/test_tba_instructor_names.py` covering both casings and a real name control case.
- Ran the helper assertions locally:
  - `To be Announced` / `To Be Announced` → `...`
  - `Jane Doe` → `Doe,Jane`
  - `Doe,Jane` unchanged
- Full Django test suite was not run here (project needs its usual Docker/uv env). The new tests are `SimpleTestCase` and do not need the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Instructor placeholders such as “To Be Announced” are now recognized consistently regardless of capitalization or surrounding spaces.
  * Course and instructor displays omit these placeholders appropriately.
  * Semester loading now maps “To Be Announced” instructor entries to Staff, matching other staff placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->