### PR TITLE
ci security enhancement and also fixed the coverage regex

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -18,12 +18,15 @@ env:
 jobs:
   deploy:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,8 @@ jobs:
       - name: Get code coverage
         id: coverage
         run: |
-          echo "percentage=$(uv run coverage report --format=total)%" >> "$GITHUB_OUTPUT"
+          total=$(uv run coverage report --format=total)
+          echo "percentage=${total}%" >> "$GITHUB_OUTPUT"
 
   eslint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: [dev, master]
 
+permissions:
+  contents: read
+
 env:
   PYTHON_TARGET: "3.12"
   DJANGO_SETTINGS_MODULE: tcf_core.settings.dev
@@ -25,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -45,12 +50,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: ${{ env.PYTHON_TARGET }}
           enable-cache: true
+          save-cache: false
 
       - name: Install dependencies
         run: uv sync --frozen --group dev --no-install-project
@@ -62,12 +70,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: ${{ env.PYTHON_TARGET }}
           enable-cache: true
+          save-cache: false
 
       - name: Install dependencies
         run: uv sync --frozen --group dev --no-install-project
@@ -91,12 +102,15 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: ${{ env.PYTHON_TARGET }}
           enable-cache: true
+          save-cache: false
 
       - name: Install dependencies
         run: uv sync --frozen --group dev --no-install-project
@@ -109,12 +123,14 @@ jobs:
       - name: Get code coverage
         id: coverage
         run: |
-          echo "percentage=$(uv run coverage report | grep -o '[0-9]\+%' | tail -1)" >> "$GITHUB_OUTPUT"
+          echo "percentage=$(uv run coverage report --format=total)%" >> "$GITHUB_OUTPUT"
 
   eslint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         id: coverage
         run: |
           total=$(uv run coverage report --format=total)
-          echo "percentage=${total}%" >> "$GITHUB_OUTPUT"
+          echo "percentage=${total}" >> "$GITHUB_OUTPUT"
 
   eslint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## GitHub Issues addressed

- This PR closes #1281 

## What I did

- Addressed the comment from #1272, which mentioned to limit the permission of the actions, set persist credentials to false to enhance security, and add save-cache to false for uv to avoid cache upload collision on cold cache runs due to duplicated computed cache key from singular machine and env.
- Another issue I found is that the test coverage report's regex is wrong, the original regex would output "20%" from "45.20%", removed the regex and just outputted the formatted text regularly in this PR.
- The other comment from #1272 on ci.yml giving off aws.yml to run on forked repo on master is fixed in #1288 

## Testing

- CI.yml ran fine locally, did not run aws.yml due to credential concern.
- Will wait for this PR's ci.yml to run to see if it's fine under github action's machine env



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Strengthened deployment and continuous integration security through read-only repository access and improved handling of checkout credentials.
  - Improved consistency across automated validation workflows.
  - Standardized coverage reporting to provide a clear total-coverage value.
  - Adjusted caching behavior for selected quality checks to improve workflow reliability.
  - Refined automated checks across deployment, linting, type validation, and application testing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->