### PR TITLE
fixing advanced search date filter by normalizing date to lower case due to inconsistency in csv files

### DIFF
--- a/tcf_website/management/commands/fetch_data.py
+++ b/tcf_website/management/commands/fetch_data.py
@@ -151,7 +151,7 @@ def compile_course_data(course_number, sem_code):
         if not m:
             return ""
         meets = m["meets"]
-        return (meets if meets != "-" else "TBA").lower()
+        return meets if meets != "-" else "TBA"
 
     def _meeting_room(m) -> str:
         if not m:

--- a/tcf_website/management/commands/load_semester.py
+++ b/tcf_website/management/commands/load_semester.py
@@ -397,14 +397,17 @@ class Command(BaseCommand):
                 try:
                     days_part, time_part = time_block.strip().split(" ", 1)
                     start_time, end_time = time_part.split(" - ")
+                    
+                    # CSV casing varies, normalize to lowercase.
+                    days_part = days_part.lower()
 
                     # Create time block with boolean fields
                     time_data = {
-                        "monday": "Mo" in days_part,
-                        "tuesday": "Tu" in days_part,
-                        "wednesday": "We" in days_part,
-                        "thursday": "Th" in days_part,
-                        "friday": "Fr" in days_part,
+                        "monday": "mo" in days_part,
+                        "tuesday": "tu" in days_part,
+                        "wednesday": "we" in days_part,
+                        "thursday": "th" in days_part,
+                        "friday": "fr" in days_part,
                         "start_time": datetime.strptime(start_time, "%I:%M%p").time(),
                         "end_time": datetime.strptime(end_time, "%I:%M%p").time(),
                     }

--- a/tcf_website/management/commands/load_semester.py
+++ b/tcf_website/management/commands/load_semester.py
@@ -397,7 +397,7 @@ class Command(BaseCommand):
                 try:
                     days_part, time_part = time_block.strip().split(" ", 1)
                     start_time, end_time = time_part.split(" - ")
-                    
+
                     # CSV casing varies, normalize to lowercase.
                     days_part = days_part.lower()
 


### PR DESCRIPTION
## What I did

- I noticed that the advance search dropdown's date filter is currently not working for Fall 2026 courses when I was browsing. It turned out that the date representation in the csv has different cases (some upper, some lower), and the Fall 2026 is the lower case one, which I is the problem. This PR normalized the date filter to lower case.

## Testing

- I loaded courses for Fall2026, did not work locally, added the fix, worked for me locally.

## Note:

This would require a semester reload on prod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of meeting-day data with varying capitalization.
  * Preserved the original casing of imported meeting-day values while continuing to display unavailable days as “TBA”.
  * Improved parsing of weekday abbreviations in semester section schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->